### PR TITLE
Removal of anchorPoint in parcellationEntityVersions.

### DIFF
--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_ACIN.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_ACIN.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_AG.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_AG.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_AMYG.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_AMYG.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_CAU.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_CAU.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_F1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_F1.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_F1M.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_F1M.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_F1MO.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_F1MO.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_F1O.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_F1O.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_F2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_F2.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_F2O.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_F2O.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_F3O.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_F3O.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_F3OP.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_F3OP.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_F3T.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_F3T.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_FUSI.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_FUSI.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_GR.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_GR.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_HES.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_HES.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_HIP.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_HIP.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_IN.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_IN.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_LING.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_LING.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_MCIN.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_MCIN.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_O1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_O1.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_O2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_O2.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_O3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_O3.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_OC.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_OC.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_P1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_P1.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_P2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_P2.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_PAL.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_PAL.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_PCIN.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_PCIN.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_PCL.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_PCL.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_PHIP.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_PHIP.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_POST.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_POST.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_PQ.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_PQ.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_PRE.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_PRE.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_PUT.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_PUT.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_Q.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_Q.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_RO.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_RO.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_SMA.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_SMA.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_SMG.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_SMG.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_T1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_T1.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_T1P.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_T1P.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_T2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_T2.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_T2P.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_T2P.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_T3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_T3.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_THA.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_THA.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_V1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_V1.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_abducensNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_abducensNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_abducensNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_abducensNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_accessoryAbducensNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_accessoryAbducensNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_accessoryFacialMotorNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_accessoryFacialMotorNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_accessoryOlfactoryBulb.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_accessoryOlfactoryBulb.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_accessoryOlfactoryBulbGlomerularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_accessoryOlfactoryBulbGlomerularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_accessoryOlfactoryBulbGranularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_accessoryOlfactoryBulbGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_accessoryOlfactoryBulbMitralLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_accessoryOlfactoryBulbMitralLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_accessoryOlfactoryTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_accessoryOlfactoryTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_accessoryOpticTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_accessoryOpticTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_accessorySpinalNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_accessorySpinalNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_accessorySupraopticGroup.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_accessorySupraopticGroup.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaDorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaDorsalPartLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaDorsalPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaDorsalPartLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaDorsalPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaDorsalPartLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaDorsalPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaDorsalPartLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaDorsalPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaDorsalPartLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaDorsalPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaPosteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaPosteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaPosteriorPartLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaPosteriorPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaPosteriorPartLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaPosteriorPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaPosteriorPartLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaPosteriorPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaPosteriorPartLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaPosteriorPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaPosteriorPartLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaPosteriorPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaVentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaVentralPartLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaVentralPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaVentralPartLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaVentralPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaVentralPartLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaVentralPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaVentralPartLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaVentralPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaVentralPartLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaVentralPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_alveus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_alveus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ammonsHorn.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ammonsHorn.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_amygdalarCapsule.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_amygdalarCapsule.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_angularPath.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_angularPath.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ansaPeduncularis.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ansaPeduncularis.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ansiformLobule.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ansiformLobule.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ansoparamedianFissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ansoparamedianFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorAmygdalarArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorAmygdalarArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaDorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaDorsalPartLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaDorsalPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaDorsalPartLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaDorsalPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaDorsalPartLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaDorsalPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaDorsalPartLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaDorsalPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaDorsalPartLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaDorsalPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaVentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaVentralPart6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaVentralPart6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaVentralPart6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaVentralPart6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaVentralPartLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaVentralPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaVentralPartLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaVentralPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaVentralPartLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaVentralPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCommissureOlfactoryLimb.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCommissureOlfactoryLimb.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCommissureTemporalLimb.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCommissureTemporalLimb.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorGroupOfTheDorsalThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorGroupOfTheDorsalThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorHypothalamicArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorHypothalamicArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorHypothalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorHypothalamicNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorHypothalamicNucleusAnteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorHypothalamicNucleusAnteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorHypothalamicNucleusCentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorHypothalamicNucleusCentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorHypothalamicNucleusDorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorHypothalamicNucleusDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorHypothalamicNucleusPosteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorHypothalamicNucleusPosteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorOlfactoryNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorOlfactoryNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorOlfactoryNucleusDorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorOlfactoryNucleusDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorOlfactoryNucleusExternalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorOlfactoryNucleusExternalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorOlfactoryNucleusLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorOlfactoryNucleusLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorOlfactoryNucleusLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorOlfactoryNucleusLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorOlfactoryNucleusLayer2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorOlfactoryNucleusLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorOlfactoryNucleusMedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorOlfactoryNucleusMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorOlfactoryNucleusPosteroventralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorOlfactoryNucleusPosteroventralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorPretectalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorPretectalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorTegmentalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorTegmentalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anterodorsalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anterodorsalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anterodorsalPreopticNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anterodorsalPreopticNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anterolateralVisualArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anterolateralVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anterolateralVisualAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anterolateralVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anterolateralVisualAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anterolateralVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anterolateralVisualAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anterolateralVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anterolateralVisualAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anterolateralVisualAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anterolateralVisualAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anterolateralVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anterolateralVisualAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anterolateralVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteromedialNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteromedialNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteromedialNucleusDorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteromedialNucleusDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteromedialNucleusVentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteromedialNucleusVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteromedialVisualArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteromedialVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteromedialVisualAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteromedialVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteromedialVisualAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteromedialVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteromedialVisualAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteromedialVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteromedialVisualAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteromedialVisualAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteromedialVisualAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteromedialVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteromedialVisualAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteromedialVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteroventralNucleusOfThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteroventralNucleusOfThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteroventralPeriventricularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteroventralPeriventricularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteroventralPreopticNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteroventralPreopticNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_arborVitae.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_arborVitae.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_arcuateHypothalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_arcuateHypothalamicNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_areaPostrema.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_areaPostrema.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_areaProstriata.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_areaProstriata.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_auditoryAreas.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_auditoryAreas.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_auditoryRadiation.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_auditoryRadiation.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_barringtonsNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_barringtonsNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_basicCellGroupsAndRegions.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_basicCellGroupsAndRegions.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_basolateralAmygdalarNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_basolateralAmygdalarNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_basolateralAmygdalarNucleusAnteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_basolateralAmygdalarNucleusAnteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_basolateralAmygdalarNucleusPosteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_basolateralAmygdalarNucleusPosteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_basolateralAmygdalarNucleusVentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_basolateralAmygdalarNucleusVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_basomedialAmygdalarNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_basomedialAmygdalarNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_basomedialAmygdalarNucleusAnteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_basomedialAmygdalarNucleusAnteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_basomedialAmygdalarNucleusPosteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_basomedialAmygdalarNucleusPosteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalis.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalis.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisAnteriorDivision.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisAnteriorDivision.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisAnteriorDivisionAnterolateralArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisAnteriorDivisionAnterolateralArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisAnteriorDivisionAnteromedialArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisAnteriorDivisionAnteromedialArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisAnteriorDivisionDorsomedialNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisAnteriorDivisionDorsomedialNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisAnteriorDivisionFusiformNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisAnteriorDivisionFusiformNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisAnteriorDivisionJuxtacapsularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisAnteriorDivisionJuxtacapsularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisAnteriorDivisionMagnocellularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisAnteriorDivisionMagnocellularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisAnteriorDivisionOvalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisAnteriorDivisionOvalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisAnteriorDivisionRhomboidNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisAnteriorDivisionRhomboidNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisAnteriorDivisionVentralNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisAnteriorDivisionVentralNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisPosteriorDivision.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisPosteriorDivision.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisPosteriorDivisionDorsalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisPosteriorDivisionDorsalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisPosteriorDivisionInterfascicularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisPosteriorDivisionInterfascicularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisPosteriorDivisionPrincipalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisPosteriorDivisionPrincipalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisPosteriorDivisionStrialExtension.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisPosteriorDivisionStrialExtension.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisPosteriorDivisionTransverseNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisPosteriorDivisionTransverseNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleusOfTheAccessoryOlfactoryTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleusOfTheAccessoryOlfactoryTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleusOfTheAnteriorCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleusOfTheAnteriorCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_brachiumOfTheInferiorColliculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_brachiumOfTheInferiorColliculus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_brachiumOfTheSuperiorColliculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_brachiumOfTheSuperiorColliculus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_brainStem.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_brainStem.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bulbocerebellarTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bulbocerebellarTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_caudoputamen.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_caudoputamen.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_centralAmygdalarNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_centralAmygdalarNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_centralAmygdalarNucleusCapsularPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_centralAmygdalarNucleusCapsularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_centralAmygdalarNucleusLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_centralAmygdalarNucleusLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_centralAmygdalarNucleusMedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_centralAmygdalarNucleusMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_centralCanalSpinalCordmedulla.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_centralCanalSpinalCordmedulla.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_centralLateralNucleusOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_centralLateralNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_centralLinearNucleusRaphe.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_centralLinearNucleusRaphe.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_centralLobule.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_centralLobule.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_centralMedialNucleusOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_centralMedialNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_centralTegmentalBundle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_centralTegmentalBundle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebalPeduncle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebalPeduncle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebellarCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebellarCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebellarCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebellarCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebellarCortexGranularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebellarCortexGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebellarCortexMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebellarCortexMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebellarCortexPurkinjeLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebellarCortexPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebellarNuclei.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebellarNuclei.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebellarPeduncles.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebellarPeduncles.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebellum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebellum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebellumRelatedFiberTracts.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebellumRelatedFiberTracts.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebralAqueduct.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebralAqueduct.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebralCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebralCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebralNuclei.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebralNuclei.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebralNucleiRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebralNucleiRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebrum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebrum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebrumRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebrumRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cervicothalamicTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cervicothalamicTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_choroidFissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_choroidFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_choroidPlexus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_choroidPlexus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cingulumBundle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cingulumBundle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_claustrum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_claustrum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cochlearNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cochlearNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cochlearNuclei.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cochlearNuclei.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cochlearNucleusSubpedunclularGranularRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cochlearNucleusSubpedunclularGranularRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_columnsOfTheFornix.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_columnsOfTheFornix.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_commissuralBranchOfStriaTerminalis.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_commissuralBranchOfStriaTerminalis.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_copulaPyramidis.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_copulaPyramidis.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_copulaPyramidisGranularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_copulaPyramidisGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_copulaPyramidisMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_copulaPyramidisMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_copulaPyramidisPurkinjeLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_copulaPyramidisPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corpusCallosum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corpusCallosum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corpusCallosumAnteriorForceps.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corpusCallosumAnteriorForceps.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corpusCallosumBody.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corpusCallosumBody.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corpusCallosumExtremeCapsule.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corpusCallosumExtremeCapsule.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corpusCallosumPosteriorForceps.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corpusCallosumPosteriorForceps.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corpusCallosumRostrum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corpusCallosumRostrum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corpusCallosumSplenium.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corpusCallosumSplenium.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaAnteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaAnteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaAnteriorPartLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaAnteriorPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaAnteriorPartLayer2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaAnteriorPartLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaAnteriorPartLayer3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaAnteriorPartLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartLateralZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartLateralZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartLateralZoneLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartLateralZoneLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartLateralZoneLayer2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartLateralZoneLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartLateralZoneLayer3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartLateralZoneLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartLateralZoneLayers12.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartLateralZoneLayers12.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartLateralZoneLayers13.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartLateralZoneLayers13.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartMedialZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartMedialZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartMedialZoneLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartMedialZoneLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartMedialZoneLayer2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartMedialZoneLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartMedialZoneLayer3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartMedialZoneLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartMedialZoneLayers12.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartMedialZoneLayers12.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartMedialZoneLayers13.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartMedialZoneLayers13.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalPlate.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalPlate.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalSubplate.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalSubplate.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticobulbarTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticobulbarTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticopontineTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticopontineTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticorubralTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticorubralTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticospinalTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticospinalTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticospinalTractCrossed.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticospinalTractCrossed.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticospinalTractUncrossed.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticospinalTractUncrossed.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticotectalTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticotectalTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cranialNerves.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cranialNerves.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_crossedTectospinalPathway.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_crossedTectospinalPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_crus1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_crus1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_crus1GranularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_crus1GranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_crus1MolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_crus1MolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_crus1PurkinjeLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_crus1PurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_crus2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_crus2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_crus2GranularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_crus2GranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_crus2MolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_crus2MolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_crus2PurkinjeLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_crus2PurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_culmen.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_culmen.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cuneateFascicle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cuneateFascicle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cuneateNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cuneateNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cuneiformNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cuneiformNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cuneocerebellarTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cuneocerebellarTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_decliveVI.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_decliveVI.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_decliveVIGranularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_decliveVIGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_decliveVIMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_decliveVIMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_decliveVIPurkinjeLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_decliveVIPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusCrest.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusCrest.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusCrestGranuleCellLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusCrestGranuleCellLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusCrestMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusCrestMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusCrestPolymorphLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusCrestPolymorphLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusGranuleCellLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusGranuleCellLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusLateralBlade.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusLateralBlade.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusLateralBladeGranuleCellLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusLateralBladeGranuleCellLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusLateralBladeMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusLateralBladeMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusLateralBladePolymorphLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusLateralBladePolymorphLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusMedialBlade.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusMedialBlade.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusMedialBladeGranuleCellLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusMedialBladeGranuleCellLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusMedialBladeMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusMedialBladeMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusMedialBladePolymorphLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusMedialBladePolymorphLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusPolymorphLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusPolymorphLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusSubgranularZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusSubgranularZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_diagonalBandNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_diagonalBandNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_directTectospinalPathway.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_directTectospinalPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dopaminergicA13Group.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dopaminergicA13Group.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_doralTegmentalDecussation.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_doralTegmentalDecussation.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalAcousticStria.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalAcousticStria.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalAuditoryArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalAuditoryArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalAuditoryAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalAuditoryAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalAuditoryAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalAuditoryAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalAuditoryAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalAuditoryAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalAuditoryAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalAuditoryAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalAuditoryAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalAuditoryAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalAuditoryAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalAuditoryAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalCochlearNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalCochlearNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalColumn.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalColumn.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalColumnNuclei.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalColumnNuclei.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalCommissureOfTheSpinalCord.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalCommissureOfTheSpinalCord.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalFornix.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalFornix.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalHippocampalCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalHippocampalCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalLimb.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalLimb.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalLongitudinalFascicle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalLongitudinalFascicle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalMotorNucleusOfTheVagusNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalMotorNucleusOfTheVagusNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalNucleusRaphe.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalNucleusRaphe.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPartOfTheLateralGeniculateComplex.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPartOfTheLateralGeniculateComplex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPartOfTheLateralGeniculateComplexCore.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPartOfTheLateralGeniculateComplexCore.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPartOfTheLateralGeniculateComplexIpsilateralZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPartOfTheLateralGeniculateComplexIpsilateralZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPartOfTheLateralGeniculateComplexShell.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPartOfTheLateralGeniculateComplexShell.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPeduncularArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPeduncularArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPeduncularAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPeduncularAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPeduncularAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPeduncularAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPeduncularAreaLayer2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPeduncularAreaLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPeduncularAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPeduncularAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPeduncularAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPeduncularAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPremammillaryNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPremammillaryNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalRoots.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalRoots.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalSpinocerebellarTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalSpinocerebellarTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalTegmentalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalTegmentalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalTegmentalTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalTegmentalTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalTerminalNucleusOfTheAccessoryOpticTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalTerminalNucleusOfTheAccessoryOpticTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalThalamusRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalThalamusRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsolateralFascicle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsolateralFascicle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsomedialNucleusOfTheHypothalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsomedialNucleusOfTheHypothalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsomedialNucleusOfTheHypothalamusAnteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsomedialNucleusOfTheHypothalamusAnteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsomedialNucleusOfTheHypothalamusPosteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsomedialNucleusOfTheHypothalamusPosteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsomedialNucleusOfTheHypothalamusVentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsomedialNucleusOfTheHypothalamusVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ectorhinalArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ectorhinalArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ectorhinalAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ectorhinalAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ectorhinalAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ectorhinalAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ectorhinalAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ectorhinalAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ectorhinalAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ectorhinalAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ectorhinalAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ectorhinalAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_edingerWestphalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_edingerWestphalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_efferentCochlearGroup.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_efferentCochlearGroup.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_efferentCochleovestibularBundle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_efferentCochleovestibularBundle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_efferentVestibularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_efferentVestibularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_endopiriformNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_endopiriformNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_endopiriformNucleusDorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_endopiriformNucleusDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_endopiriformNucleusVentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_endopiriformNucleusVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_endorhinalGroove.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_endorhinalGroove.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer2a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer2a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer2b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer2b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer4-5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer4-5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer5-6.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer5-6.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartDorsalZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartDorsalZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartDorsalZoneLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartDorsalZoneLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartDorsalZoneLayer2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartDorsalZoneLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartDorsalZoneLayer2a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartDorsalZoneLayer2a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartDorsalZoneLayer2b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartDorsalZoneLayer2b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartDorsalZoneLayer3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartDorsalZoneLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartDorsalZoneLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartDorsalZoneLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartDorsalZoneLayer5-6.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartDorsalZoneLayer5-6.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartDorsalZoneLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartDorsalZoneLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartDorsalZoneLayer6.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartDorsalZoneLayer6.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartVentralZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartVentralZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartVentralZoneLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartVentralZoneLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartVentralZoneLayer2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartVentralZoneLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartVentralZoneLayer3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartVentralZoneLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartVentralZoneLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartVentralZoneLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartVentralZoneLayer5-6.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartVentralZoneLayer5-6.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_epithalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_epithalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_epithalamusRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_epithalamusRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_externalCapsule.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_externalCapsule.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_externalCuneateNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_externalCuneateNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_externalMedullaryLaminaOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_externalMedullaryLaminaOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_extrapyramidalFiberSystems.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_extrapyramidalFiberSystems.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_facialMotorNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_facialMotorNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_facialNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_facialNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fasciculusProprius.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fasciculusProprius.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fasciculusRetroflexus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fasciculusRetroflexus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fasciolaCinerea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fasciolaCinerea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fastigialNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fastigialNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fiberTracts.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fiberTracts.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA1PyramidalLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA1PyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA1StratumLacunosummoleculare.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA1StratumLacunosummoleculare.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA1StratumOriens.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA1StratumOriens.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA1StratumRadiatum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA1StratumRadiatum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA2PyramidalLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA2PyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA2StratumLacunosummoleculare.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA2StratumLacunosummoleculare.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA2StratumOriens.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA2StratumOriens.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA2StratumRadiatum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA2StratumRadiatum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA3PyramidalLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA3PyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA3StratumLacunosummoleculare.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA3StratumLacunosummoleculare.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA3StratumLucidum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA3StratumLucidum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA3StratumOriens.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA3StratumOriens.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA3StratumRadiatum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA3StratumRadiatum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldsOfForel.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldsOfForel.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fimbria.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fimbria.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_flocculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_flocculus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_flocculusGranularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_flocculusGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_flocculusMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_flocculusMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_flocculusPurkinjeLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_flocculusPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_foliumtuberVermisVII.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_foliumtuberVermisVII.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_foliumtuberVermisVIIGranularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_foliumtuberVermisVIIGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_foliumtuberVermisVIIMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_foliumtuberVermisVIIMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_foliumtuberVermisVIIPurkinjeLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_foliumtuberVermisVIIPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fornixSystem.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fornixSystem.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fourthVentricle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fourthVentricle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_frontalPoleCerebralCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_frontalPoleCerebralCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_frontalPoleLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_frontalPoleLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_frontalPoleLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_frontalPoleLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fundusOfStriatum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fundusOfStriatum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_geniculateGroupDorsalThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_geniculateGroupDorsalThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_geniculateGroupVentralThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_geniculateGroupVentralThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_genuOfCorpusCallosum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_genuOfCorpusCallosum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_genuOfTheFacialNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_genuOfTheFacialNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_gigantocellularReticularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_gigantocellularReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_globusPallidusExternalSegment.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_globusPallidusExternalSegment.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_globusPallidusInternalSegment.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_globusPallidusInternalSegment.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_glossopharyngealNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_glossopharyngealNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_gracileFascicle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_gracileFascicle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_gracileNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_gracileNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_granularLaminaOfTheCochlearNuclei.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_granularLaminaOfTheCochlearNuclei.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_grooves.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_grooves.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_groovesOfTheCerebellarCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_groovesOfTheCerebellarCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_groovesOfTheCerebralCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_groovesOfTheCerebralCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_gustatoryAreas.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_gustatoryAreas.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_gustatoryAreasLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_gustatoryAreasLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_gustatoryAreasLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_gustatoryAreasLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_gustatoryAreasLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_gustatoryAreasLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_gustatoryAreasLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_gustatoryAreasLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_gustatoryAreasLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_gustatoryAreasLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_gustatoryAreasLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_gustatoryAreasLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_habenularCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_habenularCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hemisphericRegions.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hemisphericRegions.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hindbrain.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hindbrain.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hippocampalCommissures.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hippocampalCommissures.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hippocampalFissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hippocampalFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hippocampalFormation.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hippocampalFormation.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hippocampalRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hippocampalRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hypoglossalNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hypoglossalNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hypoglossalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hypoglossalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hypothalamicLateralZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hypothalamicLateralZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hypothalamicMedialZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hypothalamicMedialZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hypothalamohypophysialTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hypothalamohypophysialTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hypothalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hypothalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hypothalamusRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hypothalamusRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_induseumGriseum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_induseumGriseum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_inferiorCerebellarPeduncle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_inferiorCerebellarPeduncle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_inferiorColliculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_inferiorColliculus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_inferiorColliculusCentralNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_inferiorColliculusCentralNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_inferiorColliculusCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_inferiorColliculusCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_inferiorColliculusDorsalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_inferiorColliculusDorsalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_inferiorColliculusExternalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_inferiorColliculusExternalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_inferiorOlivaryComplex.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_inferiorOlivaryComplex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_inferiorSalivatoryNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_inferiorSalivatoryNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_infracerebellarNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_infracerebellarNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_infralimbicArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_infralimbicArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_infralimbicAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_infralimbicAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_infralimbicAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_infralimbicAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_infralimbicAreaLayer2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_infralimbicAreaLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_infralimbicAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_infralimbicAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_infralimbicAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_infralimbicAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_infralimbicAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_infralimbicAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_interanterodorsalNucleusOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_interanterodorsalNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_interanteromedialNucleusOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_interanteromedialNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_interbrain.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_interbrain.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_intercalatedAmygdalarNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_intercalatedAmygdalarNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_intercruralFissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_intercruralFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_interfascicularNucleusRaphe.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_interfascicularNucleusRaphe.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_intergeniculateLeafletOfTheLateralGeniculateComplex.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_intergeniculateLeafletOfTheLateralGeniculateComplex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_intermediateAcousticStria.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_intermediateAcousticStria.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_intermediateNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_intermediateNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_intermediateReticularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_intermediateReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_intermediodorsalNucleusOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_intermediodorsalNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_internalArcuateFibers.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_internalArcuateFibers.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_internalCapsule.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_internalCapsule.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_internalMedullaryLaminaOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_internalMedullaryLaminaOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_interpeduncularFossa.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_interpeduncularFossa.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_interpeduncularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_interpeduncularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_interposedNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_interposedNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_interstitialNucleusOfCajal.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_interstitialNucleusOfCajal.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_interstitialNucleusOfTheVestibularNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_interstitialNucleusOfTheVestibularNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_interventricularForamen.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_interventricularForamen.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_intralaminarNucleiOfTheDorsalThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_intralaminarNucleiOfTheDorsalThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_intraparafloccularFissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_intraparafloccularFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_islandsOfCalleja.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_islandsOfCalleja.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_isocortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_isocortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_juxtarestiformBody.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_juxtarestiformBody.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_koellikerFuseSubnucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_koellikerFuseSubnucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralAmygdalarNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralAmygdalarNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralDorsalNucleusOfThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralDorsalNucleusOfThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralForebrainBundleSystem.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralForebrainBundleSystem.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralGroupOfTheDorsalThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralGroupOfTheDorsalThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralHabenula.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralHabenula.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralHypothalamicArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralHypothalamicArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralLemniscus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralLemniscus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralMammillaryNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralMammillaryNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralOlfactoryTractBody.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralOlfactoryTractBody.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralOlfactoryTractGeneral.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralOlfactoryTractGeneral.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralPosteriorNucleusOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralPosteriorNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralPreopticArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralPreopticArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralRecess.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralRecess.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralReticularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralReticularNucleusMagnocellularPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralReticularNucleusMagnocellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralReticularNucleusParvicellularPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralReticularNucleusParvicellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralSeptalComplex.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralSeptalComplex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralSeptalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralSeptalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralSeptalNucleusCaudalCaudodorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralSeptalNucleusCaudalCaudodorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralSeptalNucleusRostralRostroventralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralSeptalNucleusRostralRostroventralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralSeptalNucleusVentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralSeptalNucleusVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralSpinothalamicTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralSpinothalamicTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralTegmentalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralTegmentalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralTerminalNucleusOfTheAccessoryOpticTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralTerminalNucleusOfTheAccessoryOpticTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralVentricle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralVentricle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralVestibularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralVestibularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralVisualArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralVisualAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralVisualAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralVisualAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralVisualAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralVisualAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralVisualAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralVisualAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterodorsalTegmentalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterodorsalTegmentalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterointermediateArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterointermediateArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterointermediateAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterointermediateAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterointermediateAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterointermediateAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterointermediateAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterointermediateAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterointermediateAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterointermediateAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterointermediateAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterointermediateAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterointermediateAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterointermediateAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterolateralAnteriorVisualArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterolateralAnteriorVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterolateralAnteriorVisualAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterolateralAnteriorVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterolateralAnteriorVisualAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterolateralAnteriorVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterolateralAnteriorVisualAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterolateralAnteriorVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterolateralAnteriorVisualAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterolateralAnteriorVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterolateralAnteriorVisualAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterolateralAnteriorVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterolateralAnteriorVisualArealayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterolateralAnteriorVisualArealayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_layer6bIsocortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_layer6bIsocortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_linearNucleusOfTheMedulla.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_linearNucleusOfTheMedulla.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lingulaI.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lingulaI.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lingulaIGranularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lingulaIGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lingulaIMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lingulaIMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lingulaIPurkinjeLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lingulaIPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleII.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleII.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIIGranularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIIGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIII.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIII.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIIIGranularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIIIGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIIIMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIIIMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIIIPurkinjeLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIIIPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIIMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIIMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIIPurkinjeLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIIPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIV.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIV.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIVGranularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIVGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIVMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIVMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIVPurkinjeLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIVPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleV.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleV.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleVGranularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleVGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleVMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleVMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleVPurkinjeLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleVPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobulesIV-V.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobulesIV-V.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobulesIV-VGranularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobulesIV-VGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobulesIV-VMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobulesIV-VMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobulesIV-VPurkinjeLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobulesIV-VPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_locusCeruleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_locusCeruleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_longitudinalAssociationBundle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_longitudinalAssociationBundle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_magnocellularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_magnocellularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_magnocellularReticularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_magnocellularReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mainOlfactoryBulb.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mainOlfactoryBulb.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mainOlfactoryBulbGlomerularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mainOlfactoryBulbGlomerularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mainOlfactoryBulbGranuleLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mainOlfactoryBulbGranuleLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mainOlfactoryBulbInnerPlexiformLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mainOlfactoryBulbInnerPlexiformLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mainOlfactoryBulbMitralLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mainOlfactoryBulbMitralLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mainOlfactoryBulbOuterPlexiformLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mainOlfactoryBulbOuterPlexiformLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_majorIslandOfCalleja.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_majorIslandOfCalleja.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mammillaryBody.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mammillaryBody.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mammillaryPeduncle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mammillaryPeduncle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mammillaryRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mammillaryRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mammillotegmentalTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mammillotegmentalTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mammilothalmicTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mammilothalmicTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialAmygdalarNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialAmygdalarNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialAmygdalarNucleusAnterodorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialAmygdalarNucleusAnterodorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialAmygdalarNucleusAnteroventralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialAmygdalarNucleusAnteroventralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialAmygdalarNucleusPosterodorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialAmygdalarNucleusPosterodorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialAmygdalarNucleusPosterodorsalPartSublayerA.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialAmygdalarNucleusPosterodorsalPartSublayerA.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialAmygdalarNucleusPosterodorsalPartSublayerB.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialAmygdalarNucleusPosterodorsalPartSublayerB.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialAmygdalarNucleusPosterodorsalPartSublayerC.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialAmygdalarNucleusPosterodorsalPartSublayerC.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialAmygdalarNucleusPosteroventralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialAmygdalarNucleusPosteroventralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialCorticohypothalmicTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialCorticohypothalmicTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialForebrainBundle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialForebrainBundle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialForebrainBundleSystem.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialForebrainBundleSystem.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialGeniculateComplex.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialGeniculateComplex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialGeniculateComplexDorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialGeniculateComplexDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialGeniculateComplexMedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialGeniculateComplexMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialGeniculateComplexVentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialGeniculateComplexVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialGroupOfTheDorsalThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialGroupOfTheDorsalThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialHabenula.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialHabenula.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialLemniscus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialLemniscus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialLongitudinalFascicle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialLongitudinalFascicle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialMammillaryNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialMammillaryNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialMammillaryNucleusMedianPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialMammillaryNucleusMedianPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialPreopticArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialPreopticArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialPreopticNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialPreopticNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialPreopticNucleusCentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialPreopticNucleusCentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialPreopticNucleusLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialPreopticNucleusLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialPreopticNucleusMedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialPreopticNucleusMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialPretectalArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialPretectalArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialSeptalComplex.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialSeptalComplex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialSeptalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialSeptalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialTerminalNucleusOfTheAccessoryOpticTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialTerminalNucleusOfTheAccessoryOpticTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialVestibularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialVestibularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialVisualArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialVisualAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialVisualAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialVisualAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialVisualAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialVisualAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialVisualArealayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialVisualArealayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medianEminence.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medianEminence.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medianPreopticNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medianPreopticNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediodorsalNucleusOfThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediodorsalNucleusOfThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediodorsalNucleusOfTheThalamusCentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediodorsalNucleusOfTheThalamusCentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediodorsalNucleusOfTheThalamusLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediodorsalNucleusOfTheThalamusLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediodorsalNucleusOfTheThalamusMedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediodorsalNucleusOfTheThalamusMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialAnteriorVisualArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialAnteriorVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialAnteriorVisualAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialAnteriorVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialAnteriorVisualAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialAnteriorVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialAnteriorVisualAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialAnteriorVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialAnteriorVisualAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialAnteriorVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialAnteriorVisualAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialAnteriorVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialAnteriorVisualArealayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialAnteriorVisualArealayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialPosteriorVisualArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialPosteriorVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialPosteriorVisualAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialPosteriorVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialPosteriorVisualAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialPosteriorVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialPosteriorVisualAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialPosteriorVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialPosteriorVisualAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialPosteriorVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialPosteriorVisualAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialPosteriorVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialPosteriorVisualArealayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialPosteriorVisualArealayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medulla.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medulla.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medullaBehavioralStateRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medullaBehavioralStateRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medullaMotorRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medullaMotorRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medullaSensoryRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medullaSensoryRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medullaryReticularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medullaryReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medullaryReticularNucleusDorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medullaryReticularNucleusDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medullaryReticularNucleusVentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medullaryReticularNucleusVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrain.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrain.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainBehavioralStateRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainBehavioralStateRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainMotorRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainMotorRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainRapheNuclei.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainRapheNuclei.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainReticularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainReticularNucleusMagnocellularPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainReticularNucleusMagnocellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainReticularNucleusMagnocellularPartGeneral.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainReticularNucleusMagnocellularPartGeneral.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainReticularNucleusParvicellularPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainReticularNucleusParvicellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainReticularNucleusRetrorubralArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainReticularNucleusRetrorubralArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainSensoryRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainSensoryRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainTractOfTheTrigeminalNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainTractOfTheTrigeminalNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainTrigeminalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainTrigeminalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_middleCerebellarPeduncle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_middleCerebellarPeduncle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_middleThalamicCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_middleThalamicCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midlineGroupOfTheDorsalThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midlineGroupOfTheDorsalThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_motorNucleusOfTrigeminal.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_motorNucleusOfTrigeminal.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_motorRootOfTheTrigeminalNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_motorRootOfTheTrigeminalNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nigrostriatalTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nigrostriatalTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nigrothalamicFibers.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nigrothalamicFibers.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nodularFissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nodularFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nodulusX.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nodulusX.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nodulusXGranularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nodulusXGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nodulusXMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nodulusXMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nodulusXPurkinjeLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nodulusXPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusAccumbens.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusAccumbens.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusAmbiguus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusAmbiguus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusAmbiguusDorsalDivision.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusAmbiguusDorsalDivision.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusAmbiguusVentralDivision.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusAmbiguusVentralDivision.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusCircularis.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusCircularis.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusIncertus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusIncertus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusIntercalatus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusIntercalatus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfDarkschewitsch.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfDarkschewitsch.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfReunions.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfReunions.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfRoller.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfRoller.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheBrachiumOfTheInferiorColliculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheBrachiumOfTheInferiorColliculus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheLateralLemniscus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheLateralLemniscus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheLateralLemniscusDorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheLateralLemniscusDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheLateralLemniscusHorizontalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheLateralLemniscusHorizontalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheLateralLemniscusVentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheLateralLemniscusVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheLateralOlfactoryTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheLateralOlfactoryTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheLateralOlfactoryTractLayer3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheLateralOlfactoryTractLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheLateralOlfactoryTractLayers13.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheLateralOlfactoryTractLayers13.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheLateralOlfactoryTractMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheLateralOlfactoryTractMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheLateralOlfactoryTractPyramidalLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheLateralOlfactoryTractPyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheOpticTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheOpticTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfThePosteriorCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfThePosteriorCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheSolitaryTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheSolitaryTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheSolitaryTractCentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheSolitaryTractCentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheSolitaryTractCommissuralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheSolitaryTractCommissuralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheSolitaryTractGelatinousPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheSolitaryTractGelatinousPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheSolitaryTractLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheSolitaryTractLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheSolitaryTractMedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheSolitaryTractMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheTrapezoidBody.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheTrapezoidBody.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusPrepositus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusPrepositus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusRapheMagnus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusRapheMagnus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusRapheObscurus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusRapheObscurus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusRaphePallidus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusRaphePallidus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusRaphePontis.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusRaphePontis.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusSagulum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusSagulum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusX.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusX.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusY.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusY.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusZ.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusZ.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_oculomotorNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_oculomotorNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_oculomotorNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_oculomotorNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_olfactoryAreas.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_olfactoryAreas.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_olfactoryNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_olfactoryNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_olfactoryNerveLayerOfMainOlfactoryBulb.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_olfactoryNerveLayerOfMainOlfactoryBulb.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_olfactoryTubercle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_olfactoryTubercle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_olfactoryTubercleLayers13.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_olfactoryTubercleLayers13.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_olfactoryTubercleMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_olfactoryTubercleMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_olfactoryTuberclePolymorphLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_olfactoryTuberclePolymorphLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_olfactoryTuberclePyramidalLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_olfactoryTuberclePyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_olivaryPretectalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_olivaryPretectalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_olivocerebellarTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_olivocerebellarTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_opticChiasm.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_opticChiasm.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_opticNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_opticNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_opticRadiation.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_opticRadiation.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_opticTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_opticTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLateralPartLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLateralPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLateralPartLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLateralPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLateralPartLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLateralPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLateralPartLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLateralPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLateralPartLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLateralPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaMedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaMedialPartLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaMedialPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaMedialPartLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaMedialPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaMedialPartLayer2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaMedialPartLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaMedialPartLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaMedialPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaMedialPartLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaMedialPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaVentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaVentrolateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaVentrolateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaVentrolateralPartLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaVentrolateralPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaVentrolateralPartLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaVentrolateralPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaVentrolateralPartLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaVentrolateralPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaVentrolateralPartLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaVentrolateralPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaVentrolateralPartLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaVentrolateralPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pallidotegmentalFascicle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pallidotegmentalFascicle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pallidothalmicPathway.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pallidothalmicPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pallidum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pallidum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pallidumCaudalRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pallidumCaudalRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pallidumDorsalRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pallidumDorsalRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pallidumMedialRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pallidumMedialRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pallidumVentralRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pallidumVentralRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabigeminalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabigeminalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleusLateralDivision.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleusLateralDivision.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleusLateralDivisionCentralLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleusLateralDivisionCentralLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleusLateralDivisionDorsalLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleusLateralDivisionDorsalLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleusLateralDivisionExternalLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleusLateralDivisionExternalLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleusLateralDivisionSuperiorLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleusLateralDivisionSuperiorLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleusLateralDivisionVentralLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleusLateralDivisionVentralLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleusMedialDivision.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleusMedialDivision.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleusMedialDivisionExternalMedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleusMedialDivisionExternalMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleusMedialDivisionMedialMedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleusMedialDivisionMedialMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleusMedialDivisionVentralMedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleusMedialDivisionVentralMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paracentralNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paracentralNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parafascicularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parafascicularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parafloccularSulcus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parafloccularSulcus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraflocculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraflocculus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraflocculusGranularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraflocculusGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraflocculusMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraflocculusMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraflocculusPurkinjeLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraflocculusPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paragigantocellularReticularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paragigantocellularReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paragigantocellularReticularNucleusDorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paragigantocellularReticularNucleusDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paragigantocellularReticularNucleusLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paragigantocellularReticularNucleusLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paramedianLobule.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paramedianLobule.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paramedianLobuleGranularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paramedianLobuleGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paramedianLobuleMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paramedianLobuleMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paramedianLobulePurkinjeLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paramedianLobulePurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paramedianReticularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paramedianReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paramedianSulcus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paramedianSulcus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parapyramidalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parapyramidalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parapyramidalNucleusDeepPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parapyramidalNucleusDeepPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parapyramidalNucleusSuperficialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parapyramidalNucleusSuperficialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parasolitaryNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parasolitaryNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parastrialNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parastrialNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parasubiculum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parasubiculum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parasubiculumLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parasubiculumLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parasubiculumLayer2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parasubiculumLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parasubiculumLayer3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parasubiculumLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parasubthalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parasubthalamicNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parataenialNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parataenialNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusDescendingDivision.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusDescendingDivision.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusDescendingDivisionDorsalParvicellularPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusDescendingDivisionDorsalParvicellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusDescendingDivisionFornicealPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusDescendingDivisionFornicealPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusDescendingDivisionLateralParvicellularPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusDescendingDivisionLateralParvicellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusDescendingDivisionMedialParvicellularPartVentralZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusDescendingDivisionMedialParvicellularPartVentralZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusMagnocellularDivision.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusMagnocellularDivision.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusMagnocellularDivisionAnteriorMagnocellularPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusMagnocellularDivisionAnteriorMagnocellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusMagnocellularDivisionMedialMagnocellularPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusMagnocellularDivisionMedialMagnocellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusMagnocellularDivisionPosteriorMagnocellularPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusMagnocellularDivisionPosteriorMagnocellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusMagnocellularDivisionPosteriorMagnocellularPartLateralZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusMagnocellularDivisionPosteriorMagnocellularPartLateralZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusMagnocellularDivisionPosteriorMagnocellularPartMedialZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusMagnocellularDivisionPosteriorMagnocellularPartMedialZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusParvicellularDivision.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusParvicellularDivision.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusParvicellularDivisionAnteriorParvicellularPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusParvicellularDivisionAnteriorParvicellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusParvicellularDivisionMedialParvicellularPartDorsalZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusParvicellularDivisionMedialParvicellularPartDorsalZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusParvicellularDivisionPeriventricularPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusParvicellularDivisionPeriventricularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularNucleusOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parvicellularReticularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parvicellularReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pedunculopontineNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pedunculopontineNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_perforantPath.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_perforantPath.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_periaqueductalGray.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_periaqueductalGray.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_perihypoglossalNuclei.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_perihypoglossalNuclei.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_peripeduncularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_peripeduncularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_perireunensisNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_perireunensisNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_perirhinalArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_perirhinalArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_perirhinalAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_perirhinalAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_perirhinalAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_perirhinalAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_perirhinalAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_perirhinalAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_perirhinalAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_perirhinalAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_perirhinalAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_perirhinalAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_periventricularBundleOfTheHypothalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_periventricularBundleOfTheHypothalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_periventricularBundleOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_periventricularBundleOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_periventricularHypothalamicNucleusAnteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_periventricularHypothalamicNucleusAnteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_periventricularHypothalamicNucleusIntermediatePart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_periventricularHypothalamicNucleusIntermediatePart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_periventricularHypothalamicNucleusPosteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_periventricularHypothalamicNucleusPosteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_periventricularHypothalamicNucleusPreopticPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_periventricularHypothalamicNucleusPreopticPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_periventricularRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_periventricularRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_periventricularZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_periventricularZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pinealBody.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pinealBody.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pinealStalk.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pinealStalk.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_piriformArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_piriformArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_piriformAreaLayers13.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_piriformAreaLayers13.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_piriformAreaMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_piriformAreaMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_piriformAreaPolymorphLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_piriformAreaPolymorphLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_piriformAreaPyramidalLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_piriformAreaPyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_piriformamygdalarArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_piriformamygdalarArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_piriformamygdalarAreaLayers13.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_piriformamygdalarAreaLayers13.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_piriformamygdalarAreaMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_piriformamygdalarAreaMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_piriformamygdalarAreaPolymorphLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_piriformamygdalarAreaPolymorphLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_piriformamygdalarAreaPyramidalLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_piriformamygdalarAreaPyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pons.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pons.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ponsBehavioralStateRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ponsBehavioralStateRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ponsMotorRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ponsMotorRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ponsSensoryRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ponsSensoryRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pontineCentralGray.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pontineCentralGray.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pontineGray.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pontineGray.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pontineReticularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pontineReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pontineReticularNucleusCaudalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pontineReticularNucleusCaudalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pontineReticularNucleusVentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pontineReticularNucleusVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postcommissuralFornix.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postcommissuralFornix.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorAmygdalarNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorAmygdalarNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorAuditoryArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorAuditoryArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorAuditoryAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorAuditoryAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorAuditoryAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorAuditoryAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorAuditoryAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorAuditoryAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorAuditoryAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorAuditoryAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorAuditoryAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorAuditoryAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorAuditoryAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorAuditoryAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorComplexOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorComplexOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorHypothalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorHypothalamicNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorLimitingNucleusOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorLimitingNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorParietalAssociationAreas.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorParietalAssociationAreas.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorParietalAssociationAreasLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorParietalAssociationAreasLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorParietalAssociationAreasLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorParietalAssociationAreasLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorParietalAssociationAreasLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorParietalAssociationAreasLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorParietalAssociationAreasLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorParietalAssociationAreasLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorParietalAssociationAreasLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorParietalAssociationAreasLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorParietalAssociationAreasLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorParietalAssociationAreasLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorPretectalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorPretectalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorSuperiorFissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorSuperiorFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posterodorsalPreopticNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posterodorsalPreopticNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posterolateralFissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posterolateralFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posterolateralVisualArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posterolateralVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posterolateralVisualAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posterolateralVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posterolateralVisualAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posterolateralVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posterolateralVisualAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posterolateralVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posterolateralVisualAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posterolateralVisualAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posterolateralVisualAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posterolateralVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posterolateralVisualAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posterolateralVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteromedialVisualArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteromedialVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteromedialVisualAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteromedialVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteromedialVisualAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteromedialVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteromedialVisualAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteromedialVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteromedialVisualAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteromedialVisualAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteromedialVisualAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteromedialVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteromedialVisualAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteromedialVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postpiriformTransitionArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postpiriformTransitionArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postpiriformTransitionAreaLayers1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postpiriformTransitionAreaLayers1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postpiriformTransitionAreaLayers13.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postpiriformTransitionAreaLayers13.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postpiriformTransitionAreaLayers2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postpiriformTransitionAreaLayers2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postpiriformTransitionAreaLayers3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postpiriformTransitionAreaLayers3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postrhinalArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postrhinalArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postrhinalAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postrhinalAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postrhinalAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postrhinalAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postrhinalAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postrhinalAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postrhinalAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postrhinalAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postrhinalAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postrhinalAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postrhinalAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postrhinalAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postsubiculum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postsubiculum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postsubiculumLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postsubiculumLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postsubiculumLayer2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postsubiculumLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postsubiculumLayer3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postsubiculumLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_precentralFissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_precentralFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_precommissuralFornixDiagonalBand.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_precommissuralFornixDiagonalBand.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_precommissuralFornixGeneral.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_precommissuralFornixGeneral.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_precommissuralNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_precommissuralNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_preculminateFissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_preculminateFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prelimbicArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prelimbicArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prelimbicAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prelimbicAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prelimbicAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prelimbicAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prelimbicAreaLayer2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prelimbicAreaLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prelimbicAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prelimbicAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prelimbicAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prelimbicAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prelimbicAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prelimbicAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_premammillaryCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_premammillaryCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_preopticCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_preopticCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_preparasubthalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_preparasubthalamicNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prepyramidalFissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prepyramidalFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_presubiculum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_presubiculum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_presubiculumLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_presubiculumLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_presubiculumLayer2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_presubiculumLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_presubiculumLayer3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_presubiculumLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pretectalRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pretectalRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryAuditoryArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryAuditoryArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryAuditoryAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryAuditoryAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryAuditoryAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryAuditoryAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryAuditoryAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryAuditoryAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryAuditoryAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryAuditoryAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryAuditoryAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryAuditoryAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryAuditoryAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryAuditoryAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryFissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryMotorArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryMotorArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryMotorAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryMotorAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryMotorAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryMotorAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryMotorAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryMotorAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryMotorAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryMotorAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryMotorAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryMotorAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaBarrelField.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaBarrelField.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaBarrelFieldLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaBarrelFieldLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaBarrelFieldLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaBarrelFieldLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaBarrelFieldLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaBarrelFieldLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaBarrelFieldLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaBarrelFieldLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaBarrelFieldLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaBarrelFieldLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaBarrelFieldLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaBarrelFieldLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLowerLimb.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLowerLimb.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLowerLimbLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLowerLimbLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLowerLimbLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLowerLimbLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLowerLimbLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLowerLimbLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLowerLimbLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLowerLimbLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLowerLimbLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLowerLimbLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLowerLimbLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLowerLimbLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaMouth.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaMouth.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaMouthLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaMouthLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaMouthLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaMouthLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaMouthLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaMouthLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaMouthLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaMouthLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaMouthLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaMouthLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaMouthLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaMouthLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaNose.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaNose.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaNoseLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaNoseLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaNoseLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaNoseLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaNoseLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaNoseLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaNoseLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaNoseLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaNoseLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaNoseLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaNoseLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaNoseLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaTrunk.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaTrunk.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaTrunkLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaTrunkLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaTrunkLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaTrunkLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaTrunkLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaTrunkLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaTrunkLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaTrunkLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaTrunkLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaTrunkLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaTrunkLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaTrunkLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUnassigned.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUnassigned.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUnassignedLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUnassignedLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUnassignedLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUnassignedLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUnassignedLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUnassignedLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUnassignedLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUnassignedLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUnassignedLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUnassignedLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUnassignedLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUnassignedLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUpperLimb.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUpperLimb.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUpperLimbLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUpperLimbLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUpperLimbLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUpperLimbLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUpperLimbLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUpperLimbLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUpperLimbLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUpperLimbLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUpperLimbLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUpperLimbLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUpperLimbLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUpperLimbLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryVisualArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryVisualAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryVisualAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryVisualAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryVisualAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryVisualAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryVisualAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryVisualAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_principalMammillaryTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_principalMammillaryTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_principalSensoryNucleusOfTheTrigeminal.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_principalSensoryNucleusOfTheTrigeminal.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_propriohypothalamicPathways.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_propriohypothalamicPathways.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_propriohypothalamicPathwaysDorsal.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_propriohypothalamicPathwaysDorsal.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_propriohypothalamicPathwaysLateral.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_propriohypothalamicPathwaysLateral.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_propriohypothalamicPathwaysMedial.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_propriohypothalamicPathwaysMedial.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_propriohypothalamicPathwaysVentral.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_propriohypothalamicPathwaysVentral.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prosubiculum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prosubiculum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prosubiculumDorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prosubiculumDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prosubiculumDorsalPartMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prosubiculumDorsalPartMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prosubiculumDorsalPartPyramidalLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prosubiculumDorsalPartPyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prosubiculumDorsalPartStratumRadiatum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prosubiculumDorsalPartStratumRadiatum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prosubiculumVentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prosubiculumVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prosubiculumVentralPartMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prosubiculumVentralPartMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prosubiculumVentralPartPyramidalLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prosubiculumVentralPartPyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prosubiculumVentralPartStratumRadiatum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prosubiculumVentralPartStratumRadiatum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pyramid.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pyramid.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pyramidalDecussation.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pyramidalDecussation.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pyramusVIII.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pyramusVIII.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pyramusVIIIGranularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pyramusVIIIGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pyramusVIIIMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pyramusVIIIMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pyramusVIIIPurkinjeLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pyramusVIIIPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_redNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_redNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_reticularNucleusOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_reticularNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_reticulocerebellarTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_reticulocerebellarTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retina.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retina.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retriculospinalTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retriculospinalTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retriculospinalTractLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retriculospinalTractLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retriculospinalTractMedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retriculospinalTractMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrochiasmaticArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrochiasmaticArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrohippocampalRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrohippocampalRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaDorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaDorsalPartLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaDorsalPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaDorsalPartLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaDorsalPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaDorsalPartLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaDorsalPartLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaDorsalPartLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaDorsalPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaDorsalPartLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaDorsalPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaDorsalPartLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaDorsalPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaLateralAgranularPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaLateralAgranularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaLateralAgranularPartLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaLateralAgranularPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaLateralAgranularPartLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaLateralAgranularPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaLateralAgranularPartLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaLateralAgranularPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaLateralAgranularPartLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaLateralAgranularPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaLateralAgranularPartLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaLateralAgranularPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaVentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaVentralPartLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaVentralPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaVentralPartLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaVentralPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaVentralPartLayer2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaVentralPartLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaVentralPartLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaVentralPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaVentralPartLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaVentralPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaVentralPartLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaVentralPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rhinalFissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rhinalFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rhinalIncisure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rhinalIncisure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rhinocele.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rhinocele.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rhomboidNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rhomboidNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_root.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_root.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostralLinearNucleusRaphe.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostralLinearNucleusRaphe.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralLateralVisualArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralLateralVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralLateralVisualAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralLateralVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralLateralVisualAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralLateralVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralLateralVisualAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralLateralVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralLateralVisualAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralLateralVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralLateralVisualAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralLateralVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralLateralVisualArealayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralLateralVisualArealayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralVisualArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rubroreticularTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rubroreticularTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rubrospinalTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rubrospinalTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_secondaryFissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_secondaryFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_secondaryMotorArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_secondaryMotorArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_secondaryMotorAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_secondaryMotorAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_secondaryMotorAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_secondaryMotorAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_secondaryMotorAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_secondaryMotorAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_secondaryMotorAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_secondaryMotorAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_secondaryMotorAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_secondaryMotorAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_sensoryRootOfTheTrigeminalNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_sensoryRootOfTheTrigeminalNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_septofimbrialNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_septofimbrialNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_septohippocampalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_septohippocampalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_simpleFissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_simpleFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_simpleLobule.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_simpleLobule.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_simpleLobuleGranularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_simpleLobuleGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_simpleLobuleMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_simpleLobuleMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_simpleLobulePurkinjeLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_simpleLobulePurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_solitaryTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_solitaryTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatomotorAreas.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatomotorAreas.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatomotorAreasLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatomotorAreasLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatomotorAreasLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatomotorAreasLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatomotorAreasLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatomotorAreasLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatomotorAreasLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatomotorAreasLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatomotorAreasLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatomotorAreasLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatosensoryAreas.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatosensoryAreas.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatosensoryAreasLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatosensoryAreasLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatosensoryAreasLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatosensoryAreasLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatosensoryAreasLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatosensoryAreasLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatosensoryAreasLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatosensoryAreasLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatosensoryAreasLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatosensoryAreasLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatosensoryAreasLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatosensoryAreasLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinalNucleusOfTheTrigeminalCaudalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinalNucleusOfTheTrigeminalCaudalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinalNucleusOfTheTrigeminalInterpolarPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinalNucleusOfTheTrigeminalInterpolarPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinalNucleusOfTheTrigeminalOralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinalNucleusOfTheTrigeminalOralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinalNucleusOfTheTrigeminalOralPartCaudalDorsomedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinalNucleusOfTheTrigeminalOralPartCaudalDorsomedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinalNucleusOfTheTrigeminalOralPartMiddleDorsomedialPartDorsalZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinalNucleusOfTheTrigeminalOralPartMiddleDorsomedialPartDorsalZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinalNucleusOfTheTrigeminalOralPartMiddleDorsomedialPartVentralZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinalNucleusOfTheTrigeminalOralPartMiddleDorsomedialPartVentralZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinalNucleusOfTheTrigeminalOralPartRostralDorsomedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinalNucleusOfTheTrigeminalOralPartRostralDorsomedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinalNucleusOfTheTrigeminalOralPartVentrolateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinalNucleusOfTheTrigeminalOralPartVentrolateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinalTractOfTheTrigeminalNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinalTractOfTheTrigeminalNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinalVestibularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinalVestibularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinocerebellarTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinocerebellarTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinocervicalTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinocervicalTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinohypothalamicPathway.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinohypothalamicPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinoolivaryPathway.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinoolivaryPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinoreticularPathway.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinoreticularPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinotectalPathway.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinotectalPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinotelenchephalicPathway.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinotelenchephalicPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinothalamicTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinothalamicTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinovestibularPathway.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinovestibularPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_striaMedullaris.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_striaMedullaris.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_striaTerminalis.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_striaTerminalis.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_striatonigralPathway.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_striatonigralPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_striatum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_striatum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_striatumDorsalRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_striatumDorsalRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_striatumVentralRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_striatumVentralRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_striatumlikeAmygdalarNuclei.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_striatumlikeAmygdalarNuclei.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subceruleusNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subceruleusNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subependymalZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subependymalZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subfornicalOrgan.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subfornicalOrgan.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subgeniculateNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subgeniculateNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subiculum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subiculum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subiculumDorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subiculumDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subiculumDorsalPartMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subiculumDorsalPartMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subiculumDorsalPartPyramidalLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subiculumDorsalPartPyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subiculumDorsalPartStratumRadiatum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subiculumDorsalPartStratumRadiatum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subiculumVentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subiculumVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subiculumVentralPartMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subiculumVentralPartMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subiculumVentralPartPyramidalLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subiculumVentralPartPyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subiculumVentralPartStratumRadiatum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subiculumVentralPartStratumRadiatum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_sublaterodorsalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_sublaterodorsalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_submedialNucleusOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_submedialNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subparafascicularArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subparafascicularArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subparafascicularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subparafascicularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subparafascicularNucleusMagnocellularPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subparafascicularNucleusMagnocellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subparafascicularNucleusParvicellularPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subparafascicularNucleusParvicellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subparaventricularZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subparaventricularZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_substantiaInnominata.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_substantiaInnominata.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_substantiaNigraCompactPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_substantiaNigraCompactPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_substantiaNigraLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_substantiaNigraLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_substantiaNigraReticularPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_substantiaNigraReticularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subthalamicFascicle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subthalamicFascicle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subthalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subthalamicNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorCentralNucleusRaphe.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorCentralNucleusRaphe.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorCentralNucleusRapheLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorCentralNucleusRapheLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorCentralNucleusRapheMedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorCentralNucleusRapheMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorCerebelarPeduncles.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorCerebelarPeduncles.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorCerebellarPeduncleDecussation.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorCerebellarPeduncleDecussation.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusMotorRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusMotorRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusMotorRelatedDeepGrayLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusMotorRelatedDeepGrayLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusMotorRelatedDeepWhiteLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusMotorRelatedDeepWhiteLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusMotorRelatedIntermediateGrayLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusMotorRelatedIntermediateGrayLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusMotorRelatedIntermediateGrayLayerSublayerA.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusMotorRelatedIntermediateGrayLayerSublayerA.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusMotorRelatedIntermediateGrayLayerSublayerB.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusMotorRelatedIntermediateGrayLayerSublayerB.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusMotorRelatedIntermediateGrayLayerSublayerC.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusMotorRelatedIntermediateGrayLayerSublayerC.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusMotorRelatedIntermediateWhiteLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusMotorRelatedIntermediateWhiteLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusOpticLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusOpticLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusSensoryRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusSensoryRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusSuperficialGrayLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusSuperficialGrayLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusZonalLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusZonalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorOlivaryComplex.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorOlivaryComplex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorOlivaryComplexLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorOlivaryComplexLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorOlivaryComplexMedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorOlivaryComplexMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorOlivaryComplexPeriolivaryRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorOlivaryComplexPeriolivaryRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorSalivatoryNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorSalivatoryNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorVestibularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorVestibularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supplementalSomatosensoryArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supplementalSomatosensoryArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supplementalSomatosensoryAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supplementalSomatosensoryAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supplementalSomatosensoryAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supplementalSomatosensoryAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supplementalSomatosensoryAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supplementalSomatosensoryAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supplementalSomatosensoryAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supplementalSomatosensoryAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supplementalSomatosensoryAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supplementalSomatosensoryAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supplementalSomatosensoryAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supplementalSomatosensoryAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supracallosalCerebralWhiteMatter.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supracallosalCerebralWhiteMatter.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_suprachiasmaticNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_suprachiasmaticNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_suprachiasmaticPreopticNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_suprachiasmaticPreopticNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_suprageniculateNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_suprageniculateNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supragenualNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supragenualNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supramammillaryDecussation.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supramammillaryDecussation.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supramammillaryNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supramammillaryNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supramammillaryNucleusLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supramammillaryNucleusLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supramammillaryNucleusMedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supramammillaryNucleusMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supraopticCommissures.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supraopticCommissures.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supraopticCommissuresAnterior.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supraopticCommissuresAnterior.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supraopticCommissuresDorsal.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supraopticCommissuresDorsal.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supraopticCommissuresVentral.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supraopticCommissuresVentral.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supraopticNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supraopticNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supratrigeminalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supratrigeminalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTecta.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTecta.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaDorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaDorsalPartLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaDorsalPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaDorsalPartLayer2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaDorsalPartLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaDorsalPartLayer3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaDorsalPartLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaDorsalPartLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaDorsalPartLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaDorsalPartLayers14.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaDorsalPartLayers14.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaVentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaVentralPartLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaVentralPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaVentralPartLayer2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaVentralPartLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaVentralPartLayer3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaVentralPartLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaVentralPartLayers13.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaVentralPartLayers13.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_tectospinalPathway.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_tectospinalPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_tectothalamicPathway.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_tectothalamicPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_tegmentalReticularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_tegmentalReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_temporalAssociationAreas.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_temporalAssociationAreas.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_temporalAssociationAreasLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_temporalAssociationAreasLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_temporalAssociationAreasLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_temporalAssociationAreasLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_temporalAssociationAreasLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_temporalAssociationAreasLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_temporalAssociationAreasLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_temporalAssociationAreasLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_temporalAssociationAreasLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_temporalAssociationAreasLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_temporalAssociationAreasLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_temporalAssociationAreasLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_terminalNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_terminalNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_thalamicPeduncles.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_thalamicPeduncles.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_thalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_thalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_thalamusPolymodalAssociationCortexRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_thalamusPolymodalAssociationCortexRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_thalamusRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_thalamusRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_thalamusSensorymotorCortexRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_thalamusSensorymotorCortexRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_thirdVentricle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_thirdVentricle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_trapezoidBody.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_trapezoidBody.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_triangularNucleusOfSeptum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_triangularNucleusOfSeptum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_trigeminalNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_trigeminalNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_trigeminocerebellarTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_trigeminocerebellarTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_trochlearNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_trochlearNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_trochlearNerveDecussation.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_trochlearNerveDecussation.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_trochlearNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_trochlearNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_tuberalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_tuberalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_tuberomammillaryNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_tuberomammillaryNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_tuberomammillaryNucleusDorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_tuberomammillaryNucleusDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_tuberomammillaryNucleusVentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_tuberomammillaryNucleusVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_uncinateFascicle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_uncinateFascicle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_uvulaIX.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_uvulaIX.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_uvulaIXGranularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_uvulaIXGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_uvulaIXMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_uvulaIXMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_uvulaIXPurkinjeLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_uvulaIXPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_vagusNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_vagusNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_vascularOrganOfTheLaminaTerminalis.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_vascularOrganOfTheLaminaTerminalis.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralAnteriorlateralComplexOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralAnteriorlateralComplexOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralAuditoryArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralAuditoryArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralAuditoryAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralAuditoryAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralAuditoryAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralAuditoryAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralAuditoryAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralAuditoryAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralAuditoryAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralAuditoryAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralAuditoryAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralAuditoryAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralAuditoryAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralAuditoryAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralCochlearNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralCochlearNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralCommissureOfTheSpinalCord.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralCommissureOfTheSpinalCord.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralGroupOfTheDorsalThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralGroupOfTheDorsalThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralHippocampalCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralHippocampalCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralMedialNucleusOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralMedialNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralPartOfTheLateralGeniculateComplex.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralPartOfTheLateralGeniculateComplex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralPartOfTheLateralGeniculateComplexLateralZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralPartOfTheLateralGeniculateComplexLateralZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralPartOfTheLateralGeniculateComplexMedialZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralPartOfTheLateralGeniculateComplexMedialZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralPosteriorComplexOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralPosteriorComplexOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralPosterolateralNucleusOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralPosterolateralNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralPosterolateralNucleusOfTheThalamusParvicellularPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralPosterolateralNucleusOfTheThalamusParvicellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralPosteromedialNucleusOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralPosteromedialNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralPosteromedialNucleusOfTheThalamusParvicellularPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralPosteromedialNucleusOfTheThalamusParvicellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralPremammillaryNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralPremammillaryNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralRoots.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralRoots.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralSpinocerebellarTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralSpinocerebellarTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralSpinothalamicTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralSpinothalamicTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralTegmentalArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralTegmentalArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralTegmentalDecussation.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralTegmentalDecussation.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralTegmentalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralTegmentalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventricularSystems.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventricularSystems.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventrolateralHypothalamicTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventrolateralHypothalamicTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventrolateralPreopticNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventrolateralPreopticNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventromedialHypothalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventromedialHypothalamicNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventromedialHypothalamicNucleusAnteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventromedialHypothalamicNucleusAnteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventromedialHypothalamicNucleusCentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventromedialHypothalamicNucleusCentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventromedialHypothalamicNucleusDorsomedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventromedialHypothalamicNucleusDorsomedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventromedialHypothalamicNucleusVentrolateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventromedialHypothalamicNucleusVentrolateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_vermalRegions.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_vermalRegions.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_vestibularNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_vestibularNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_vestibularNuclei.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_vestibularNuclei.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_vestibulocochlearNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_vestibulocochlearNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_vestibulospinalPathway.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_vestibulospinalPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visceralArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visceralArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visceralAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visceralAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visceralAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visceralAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visceralAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visceralAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visceralAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visceralAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visceralAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visceralAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visceralAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visceralAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visualAreas.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visualAreas.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visualAreasLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visualAreasLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visualAreasLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visualAreasLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visualAreasLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visualAreasLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visualAreasLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visualAreasLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visualAreasLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visualAreasLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visualAreasLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visualAreasLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_vomeronasalNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_vomeronasalNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_zonaIncerta.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_zonaIncerta.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_abducensNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_abducensNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_abducensNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_abducensNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessoryAbducensNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessoryAbducensNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessoryFacialMotorNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessoryFacialMotorNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessoryOlfactoryBulb.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessoryOlfactoryBulb.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessoryOlfactoryBulbGlomerularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessoryOlfactoryBulbGlomerularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessoryOlfactoryBulbGranularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessoryOlfactoryBulbGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessoryOlfactoryBulbMitralLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessoryOlfactoryBulbMitralLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessoryOlfactoryTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessoryOlfactoryTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessoryOpticTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessoryOpticTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessorySpinalNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessorySpinalNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessorySupraopticGroup.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessorySupraopticGroup.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessoryTrigeminalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessoryTrigeminalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaDorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaDorsalPartLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaDorsalPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaDorsalPartLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaDorsalPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaDorsalPartLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaDorsalPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaDorsalPartLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaDorsalPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaDorsalPartLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaDorsalPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaPosteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaPosteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaPosteriorPartLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaPosteriorPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaPosteriorPartLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaPosteriorPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaPosteriorPartLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaPosteriorPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaPosteriorPartLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaPosteriorPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaPosteriorPartLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaPosteriorPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaVentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaVentralPartLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaVentralPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaVentralPartLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaVentralPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaVentralPartLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaVentralPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaVentralPartLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaVentralPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaVentralPartLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaVentralPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_alveus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_alveus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ammonsHorn.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ammonsHorn.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_amygdalarCapsule.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_amygdalarCapsule.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_angularPath.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_angularPath.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ansaPeduncularis.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ansaPeduncularis.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ansiformLobule.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ansiformLobule.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ansoparamedianFissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ansoparamedianFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorAmygdalarArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorAmygdalarArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaDorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaDorsalPartLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaDorsalPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaDorsalPartLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaDorsalPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaDorsalPartLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaDorsalPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaDorsalPartLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaDorsalPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaDorsalPartLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaDorsalPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaVentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaVentralPart6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaVentralPart6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaVentralPart6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaVentralPart6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaVentralPartLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaVentralPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaVentralPartLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaVentralPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaVentralPartLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaVentralPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCommissureOlfactoryLimb.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCommissureOlfactoryLimb.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCommissureTemporalLimb.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCommissureTemporalLimb.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorGroupOfTheDorsalThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorGroupOfTheDorsalThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorHypothalamicArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorHypothalamicArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorHypothalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorHypothalamicNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorHypothalamicNucleusAnteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorHypothalamicNucleusAnteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorHypothalamicNucleusCentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorHypothalamicNucleusCentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorHypothalamicNucleusDorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorHypothalamicNucleusDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorHypothalamicNucleusPosteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorHypothalamicNucleusPosteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorOlfactoryNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorOlfactoryNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorOlfactoryNucleusDorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorOlfactoryNucleusDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorOlfactoryNucleusExternalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorOlfactoryNucleusExternalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorOlfactoryNucleusLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorOlfactoryNucleusLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorOlfactoryNucleusLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorOlfactoryNucleusLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorOlfactoryNucleusLayer2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorOlfactoryNucleusLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorOlfactoryNucleusMedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorOlfactoryNucleusMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorOlfactoryNucleusPosteroventralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorOlfactoryNucleusPosteroventralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorPretectalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorPretectalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorTegmentalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorTegmentalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anterodorsalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anterodorsalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anterodorsalPreopticNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anterodorsalPreopticNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anterolateralVisualArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anterolateralVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anterolateralVisualAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anterolateralVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anterolateralVisualAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anterolateralVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anterolateralVisualAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anterolateralVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anterolateralVisualAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anterolateralVisualAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anterolateralVisualAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anterolateralVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anterolateralVisualAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anterolateralVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteromedialNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteromedialNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteromedialNucleusDorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteromedialNucleusDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteromedialNucleusVentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteromedialNucleusVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteromedialVisualArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteromedialVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteromedialVisualAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteromedialVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteromedialVisualAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteromedialVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteromedialVisualAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteromedialVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteromedialVisualAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteromedialVisualAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteromedialVisualAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteromedialVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteromedialVisualAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteromedialVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteroventralNucleusOfThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteroventralNucleusOfThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteroventralPeriventricularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteroventralPeriventricularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteroventralPreopticNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteroventralPreopticNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_arborVitae.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_arborVitae.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_arcuateHypothalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_arcuateHypothalamicNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_areaPostrema.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_areaPostrema.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_areaProstriata.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_areaProstriata.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_auditoryAreas.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_auditoryAreas.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_auditoryRadiation.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_auditoryRadiation.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_barringtonsNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_barringtonsNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_basicCellGroupsAndRegions.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_basicCellGroupsAndRegions.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_basolateralAmygdalarNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_basolateralAmygdalarNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_basolateralAmygdalarNucleusAnteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_basolateralAmygdalarNucleusAnteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_basolateralAmygdalarNucleusPosteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_basolateralAmygdalarNucleusPosteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_basolateralAmygdalarNucleusVentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_basolateralAmygdalarNucleusVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_basomedialAmygdalarNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_basomedialAmygdalarNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_basomedialAmygdalarNucleusAnteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_basomedialAmygdalarNucleusAnteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_basomedialAmygdalarNucleusPosteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_basomedialAmygdalarNucleusPosteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalis.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalis.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisAnteriorDivision.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisAnteriorDivision.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisAnteriorDivisionAnterolateralArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisAnteriorDivisionAnterolateralArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisAnteriorDivisionAnteromedialArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisAnteriorDivisionAnteromedialArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisAnteriorDivisionDorsomedialNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisAnteriorDivisionDorsomedialNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisAnteriorDivisionFusiformNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisAnteriorDivisionFusiformNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisAnteriorDivisionJuxtacapsularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisAnteriorDivisionJuxtacapsularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisAnteriorDivisionMagnocellularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisAnteriorDivisionMagnocellularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisAnteriorDivisionOvalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisAnteriorDivisionOvalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisAnteriorDivisionRhomboidNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisAnteriorDivisionRhomboidNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisAnteriorDivisionVentralNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisAnteriorDivisionVentralNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisPosteriorDivision.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisPosteriorDivision.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisPosteriorDivisionDorsalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisPosteriorDivisionDorsalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisPosteriorDivisionInterfascicularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisPosteriorDivisionInterfascicularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisPosteriorDivisionPrincipalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisPosteriorDivisionPrincipalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisPosteriorDivisionStrialExtension.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisPosteriorDivisionStrialExtension.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisPosteriorDivisionTransverseNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisPosteriorDivisionTransverseNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleusOfTheAccessoryOlfactoryTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleusOfTheAccessoryOlfactoryTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleusOfTheAnteriorCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleusOfTheAnteriorCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_brachiumOfTheInferiorColliculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_brachiumOfTheInferiorColliculus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_brachiumOfTheSuperiorColliculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_brachiumOfTheSuperiorColliculus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_brainStem.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_brainStem.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bulbocerebellarTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bulbocerebellarTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_caudoputamen.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_caudoputamen.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_centralAmygdalarNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_centralAmygdalarNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_centralAmygdalarNucleusCapsularPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_centralAmygdalarNucleusCapsularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_centralAmygdalarNucleusLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_centralAmygdalarNucleusLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_centralAmygdalarNucleusMedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_centralAmygdalarNucleusMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_centralCanalSpinalCordmedulla.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_centralCanalSpinalCordmedulla.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_centralLateralNucleusOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_centralLateralNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_centralLinearNucleusRaphe.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_centralLinearNucleusRaphe.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_centralLobule.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_centralLobule.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_centralMedialNucleusOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_centralMedialNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_centralTegmentalBundle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_centralTegmentalBundle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebalPeduncle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebalPeduncle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebellarCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebellarCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebellarCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebellarCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebellarCortexGranularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebellarCortexGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebellarCortexMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebellarCortexMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebellarCortexPurkinjeLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebellarCortexPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebellarNuclei.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebellarNuclei.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebellarPeduncles.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebellarPeduncles.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebellum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebellum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebellumRelatedFiberTracts.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebellumRelatedFiberTracts.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebralAqueduct.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebralAqueduct.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebralCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebralCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebralNuclei.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebralNuclei.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebralNucleiRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebralNucleiRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebrum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebrum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebrumRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebrumRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cervicothalamicTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cervicothalamicTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_choroidFissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_choroidFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_choroidPlexus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_choroidPlexus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cingulumBundle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cingulumBundle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_claustrum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_claustrum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cochlearNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cochlearNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cochlearNuclei.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cochlearNuclei.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cochlearNucleusSubpedunclularGranularRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cochlearNucleusSubpedunclularGranularRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_columnsOfTheFornix.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_columnsOfTheFornix.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_commissuralBranchOfStriaTerminalis.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_commissuralBranchOfStriaTerminalis.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_copulaPyramidis.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_copulaPyramidis.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_copulaPyramidisGranularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_copulaPyramidisGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_copulaPyramidisMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_copulaPyramidisMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_copulaPyramidisPurkinjeLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_copulaPyramidisPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corpusCallosum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corpusCallosum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corpusCallosumAnteriorForceps.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corpusCallosumAnteriorForceps.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corpusCallosumBody.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corpusCallosumBody.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corpusCallosumExtremeCapsule.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corpusCallosumExtremeCapsule.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corpusCallosumPosteriorForceps.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corpusCallosumPosteriorForceps.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corpusCallosumRostrum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corpusCallosumRostrum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corpusCallosumSplenium.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corpusCallosumSplenium.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaAnteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaAnteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaAnteriorPartLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaAnteriorPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaAnteriorPartLayer2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaAnteriorPartLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaAnteriorPartLayer3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaAnteriorPartLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartLateralZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartLateralZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartLateralZoneLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartLateralZoneLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartLateralZoneLayer2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartLateralZoneLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartLateralZoneLayer3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartLateralZoneLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartLateralZoneLayers12.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartLateralZoneLayers12.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartLateralZoneLayers13.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartLateralZoneLayers13.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartMedialZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartMedialZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartMedialZoneLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartMedialZoneLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartMedialZoneLayer2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartMedialZoneLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartMedialZoneLayer3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartMedialZoneLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartMedialZoneLayers12.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartMedialZoneLayers12.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartMedialZoneLayers13.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartMedialZoneLayers13.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalPlate.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalPlate.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalSubplate.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalSubplate.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticobulbarTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticobulbarTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticopontineTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticopontineTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticorubralTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticorubralTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticospinalTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticospinalTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticospinalTractCrossed.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticospinalTractCrossed.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticospinalTractUncrossed.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticospinalTractUncrossed.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticotectalTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticotectalTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cranialNerves.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cranialNerves.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_crossedTectospinalPathway.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_crossedTectospinalPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_crus1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_crus1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_crus1GranularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_crus1GranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_crus1MolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_crus1MolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_crus1PurkinjeLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_crus1PurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_crus2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_crus2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_crus2GranularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_crus2GranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_crus2MolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_crus2MolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_crus2PurkinjeLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_crus2PurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_culmen.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_culmen.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cuneateFascicle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cuneateFascicle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cuneateNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cuneateNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cuneiformNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cuneiformNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cuneocerebellarTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cuneocerebellarTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_decliveVI.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_decliveVI.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_decliveVIGranularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_decliveVIGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_decliveVIMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_decliveVIMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_decliveVIPurkinjeLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_decliveVIPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusCrest.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusCrest.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusCrestGranuleCellLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusCrestGranuleCellLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusCrestMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusCrestMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusCrestPolymorphLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusCrestPolymorphLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusGranuleCellLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusGranuleCellLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusLateralBlade.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusLateralBlade.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusLateralBladeGranuleCellLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusLateralBladeGranuleCellLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusLateralBladeMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusLateralBladeMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusLateralBladePolymorphLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusLateralBladePolymorphLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusMedialBlade.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusMedialBlade.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusMedialBladeGranuleCellLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusMedialBladeGranuleCellLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusMedialBladeMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusMedialBladeMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusMedialBladePolymorphLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusMedialBladePolymorphLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusPolymorphLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusPolymorphLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusSubgranularZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusSubgranularZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_diagonalBandNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_diagonalBandNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_directTectospinalPathway.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_directTectospinalPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dopaminergicA13Group.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dopaminergicA13Group.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_doralTegmentalDecussation.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_doralTegmentalDecussation.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalAcousticStria.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalAcousticStria.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalAuditoryArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalAuditoryArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalAuditoryAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalAuditoryAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalAuditoryAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalAuditoryAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalAuditoryAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalAuditoryAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalAuditoryAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalAuditoryAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalAuditoryAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalAuditoryAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalAuditoryAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalAuditoryAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalCochlearNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalCochlearNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalColumn.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalColumn.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalColumnNuclei.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalColumnNuclei.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalCommissureOfTheSpinalCord.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalCommissureOfTheSpinalCord.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalFornix.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalFornix.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalHippocampalCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalHippocampalCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalLimb.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalLimb.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalLongitudinalFascicle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalLongitudinalFascicle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalMotorNucleusOfTheVagusNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalMotorNucleusOfTheVagusNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalNucleusRaphe.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalNucleusRaphe.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPartOfTheLateralGeniculateComplex.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPartOfTheLateralGeniculateComplex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPartOfTheLateralGeniculateComplexCore.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPartOfTheLateralGeniculateComplexCore.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPartOfTheLateralGeniculateComplexIpsilateralZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPartOfTheLateralGeniculateComplexIpsilateralZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPartOfTheLateralGeniculateComplexShell.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPartOfTheLateralGeniculateComplexShell.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPeduncularArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPeduncularArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPeduncularAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPeduncularAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPeduncularAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPeduncularAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPeduncularAreaLayer2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPeduncularAreaLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPeduncularAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPeduncularAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPeduncularAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPeduncularAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPremammillaryNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPremammillaryNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalRoots.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalRoots.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalSpinocerebellarTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalSpinocerebellarTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalTegmentalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalTegmentalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalTegmentalTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalTegmentalTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalTerminalNucleusOfTheAccessoryOpticTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalTerminalNucleusOfTheAccessoryOpticTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalThalamusRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalThalamusRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsolateralFascicle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsolateralFascicle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsomedialNucleusOfTheHypothalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsomedialNucleusOfTheHypothalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsomedialNucleusOfTheHypothalamusAnteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsomedialNucleusOfTheHypothalamusAnteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsomedialNucleusOfTheHypothalamusPosteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsomedialNucleusOfTheHypothalamusPosteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsomedialNucleusOfTheHypothalamusVentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsomedialNucleusOfTheHypothalamusVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ectorhinalArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ectorhinalArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ectorhinalAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ectorhinalAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ectorhinalAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ectorhinalAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ectorhinalAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ectorhinalAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ectorhinalAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ectorhinalAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ectorhinalAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ectorhinalAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_edingerWestphalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_edingerWestphalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_efferentCochlearGroup.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_efferentCochlearGroup.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_efferentCochleovestibularBundle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_efferentCochleovestibularBundle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_efferentVestibularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_efferentVestibularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_endopiriformNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_endopiriformNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_endopiriformNucleusDorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_endopiriformNucleusDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_endopiriformNucleusVentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_endopiriformNucleusVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_endorhinalGroove.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_endorhinalGroove.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer2a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer2a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer2b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer2b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer4-5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer4-5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer5-6.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer5-6.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartDorsalZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartDorsalZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartDorsalZoneLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartDorsalZoneLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartDorsalZoneLayer2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartDorsalZoneLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartDorsalZoneLayer2a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartDorsalZoneLayer2a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartDorsalZoneLayer2b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartDorsalZoneLayer2b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartDorsalZoneLayer3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartDorsalZoneLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartDorsalZoneLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartDorsalZoneLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartDorsalZoneLayer5-6.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartDorsalZoneLayer5-6.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartDorsalZoneLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartDorsalZoneLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartDorsalZoneLayer6.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartDorsalZoneLayer6.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartVentralZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartVentralZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartVentralZoneLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartVentralZoneLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartVentralZoneLayer2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartVentralZoneLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartVentralZoneLayer3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartVentralZoneLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartVentralZoneLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartVentralZoneLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartVentralZoneLayer5-6.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartVentralZoneLayer5-6.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_epithalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_epithalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_epithalamusRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_epithalamusRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ethmoidNucleusOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ethmoidNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_externalCapsule.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_externalCapsule.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_externalCuneateNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_externalCuneateNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_externalMedullaryLaminaOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_externalMedullaryLaminaOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_extrapyramidalFiberSystems.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_extrapyramidalFiberSystems.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_facialMotorNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_facialMotorNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_facialNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_facialNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fasciculusProprius.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fasciculusProprius.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fasciculusRetroflexus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fasciculusRetroflexus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fasciolaCinerea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fasciolaCinerea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fastigialNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fastigialNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fiberTracts.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fiberTracts.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA1PyramidalLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA1PyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA1StratumLacunosummoleculare.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA1StratumLacunosummoleculare.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA1StratumOriens.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA1StratumOriens.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA1StratumRadiatum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA1StratumRadiatum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA2PyramidalLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA2PyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA2StratumLacunosummoleculare.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA2StratumLacunosummoleculare.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA2StratumOriens.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA2StratumOriens.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA2StratumRadiatum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA2StratumRadiatum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA3PyramidalLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA3PyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA3StratumLacunosummoleculare.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA3StratumLacunosummoleculare.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA3StratumLucidum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA3StratumLucidum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA3StratumOriens.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA3StratumOriens.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA3StratumRadiatum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA3StratumRadiatum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldsOfForel.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldsOfForel.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fimbria.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fimbria.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_flocculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_flocculus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_flocculusGranularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_flocculusGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_flocculusMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_flocculusMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_flocculusPurkinjeLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_flocculusPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_foliumtuberVermisVII.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_foliumtuberVermisVII.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_foliumtuberVermisVIIGranularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_foliumtuberVermisVIIGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_foliumtuberVermisVIIMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_foliumtuberVermisVIIMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_foliumtuberVermisVIIPurkinjeLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_foliumtuberVermisVIIPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fornixSystem.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fornixSystem.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fourthVentricle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fourthVentricle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_frontalPoleCerebralCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_frontalPoleCerebralCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_frontalPoleLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_frontalPoleLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_frontalPoleLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_frontalPoleLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_frontalPoleLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_frontalPoleLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_frontalPoleLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_frontalPoleLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_frontalPoleLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_frontalPoleLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fundusOfStriatum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fundusOfStriatum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_geniculateGroupDorsalThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_geniculateGroupDorsalThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_geniculateGroupVentralThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_geniculateGroupVentralThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_genuOfCorpusCallosum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_genuOfCorpusCallosum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_genuOfTheFacialNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_genuOfTheFacialNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_gigantocellularReticularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_gigantocellularReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_globusPallidusExternalSegment.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_globusPallidusExternalSegment.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_globusPallidusInternalSegment.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_globusPallidusInternalSegment.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_glossopharyngealNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_glossopharyngealNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_gracileFascicle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_gracileFascicle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_gracileNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_gracileNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_granularLaminaOfTheCochlearNuclei.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_granularLaminaOfTheCochlearNuclei.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_grooves.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_grooves.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_groovesOfTheCerebellarCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_groovesOfTheCerebellarCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_groovesOfTheCerebralCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_groovesOfTheCerebralCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_gustatoryAreas.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_gustatoryAreas.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_gustatoryAreasLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_gustatoryAreasLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_gustatoryAreasLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_gustatoryAreasLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_gustatoryAreasLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_gustatoryAreasLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_gustatoryAreasLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_gustatoryAreasLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_gustatoryAreasLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_gustatoryAreasLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_gustatoryAreasLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_gustatoryAreasLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_habenularCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_habenularCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hemisphericRegions.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hemisphericRegions.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hindbrain.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hindbrain.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hippocampalCommissures.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hippocampalCommissures.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hippocampalFissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hippocampalFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hippocampalFormation.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hippocampalFormation.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hippocampalRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hippocampalRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hippocampoamygdalarTransitionArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hippocampoamygdalarTransitionArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hypoglossalNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hypoglossalNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hypoglossalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hypoglossalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hypothalamicLateralZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hypothalamicLateralZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hypothalamicMedialZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hypothalamicMedialZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hypothalamohypophysialTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hypothalamohypophysialTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hypothalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hypothalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hypothalamusRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hypothalamusRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_induseumGriseum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_induseumGriseum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_inferiorCerebellarPeduncle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_inferiorCerebellarPeduncle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_inferiorColliculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_inferiorColliculus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_inferiorColliculusCentralNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_inferiorColliculusCentralNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_inferiorColliculusCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_inferiorColliculusCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_inferiorColliculusDorsalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_inferiorColliculusDorsalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_inferiorColliculusExternalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_inferiorColliculusExternalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_inferiorOlivaryComplex.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_inferiorOlivaryComplex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_inferiorSalivatoryNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_inferiorSalivatoryNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_infracerebellarNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_infracerebellarNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_infralimbicArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_infralimbicArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_infralimbicAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_infralimbicAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_infralimbicAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_infralimbicAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_infralimbicAreaLayer2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_infralimbicAreaLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_infralimbicAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_infralimbicAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_infralimbicAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_infralimbicAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_infralimbicAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_infralimbicAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interanterodorsalNucleusOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interanterodorsalNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interanteromedialNucleusOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interanteromedialNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interbrain.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interbrain.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intercalatedAmygdalarNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intercalatedAmygdalarNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intercollicularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intercollicularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intercruralFissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intercruralFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interfascicularNucleusRaphe.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interfascicularNucleusRaphe.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intergeniculateLeafletOfTheLateralGeniculateComplex.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intergeniculateLeafletOfTheLateralGeniculateComplex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intermediateAcousticStria.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intermediateAcousticStria.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intermediateGeniculateNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intermediateGeniculateNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intermediateNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intermediateNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intermediateReticularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intermediateReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intermediodorsalNucleusOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intermediodorsalNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_internalArcuateFibers.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_internalArcuateFibers.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_internalCapsule.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_internalCapsule.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_internalMedullaryLaminaOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_internalMedullaryLaminaOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interpeduncularFossa.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interpeduncularFossa.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interpeduncularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interpeduncularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interpeduncularNucleusApical.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interpeduncularNucleusApical.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interpeduncularNucleusCaudal.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interpeduncularNucleusCaudal.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interpeduncularNucleusDorsolateral.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interpeduncularNucleusDorsolateral.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interpeduncularNucleusDorsomedial.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interpeduncularNucleusDorsomedial.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interpeduncularNucleusIntermediate.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interpeduncularNucleusIntermediate.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interpeduncularNucleusLateral.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interpeduncularNucleusLateral.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interpeduncularNucleusRostral.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interpeduncularNucleusRostral.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interpeduncularNucleusRostrolateral.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interpeduncularNucleusRostrolateral.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interposedNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interposedNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interstitialNucleusOfCajal.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interstitialNucleusOfCajal.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interstitialNucleusOfTheVestibularNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interstitialNucleusOfTheVestibularNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intertrigeminalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intertrigeminalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interventricularForamen.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interventricularForamen.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intralaminarNucleiOfTheDorsalThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intralaminarNucleiOfTheDorsalThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intraparafloccularFissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intraparafloccularFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_islandsOfCalleja.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_islandsOfCalleja.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_isocortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_isocortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_juxtarestiformBody.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_juxtarestiformBody.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_koellikerFuseSubnucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_koellikerFuseSubnucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralAmygdalarNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralAmygdalarNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralDorsalNucleusOfThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralDorsalNucleusOfThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralForebrainBundleSystem.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralForebrainBundleSystem.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralGroupOfTheDorsalThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralGroupOfTheDorsalThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralHabenula.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralHabenula.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralHypothalamicArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralHypothalamicArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralLemniscus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralLemniscus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralMammillaryNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralMammillaryNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralOlfactoryTractBody.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralOlfactoryTractBody.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralOlfactoryTractGeneral.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralOlfactoryTractGeneral.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralPosteriorNucleusOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralPosteriorNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralPreopticArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralPreopticArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralRecess.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralRecess.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralReticularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralReticularNucleusMagnocellularPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralReticularNucleusMagnocellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralReticularNucleusParvicellularPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralReticularNucleusParvicellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralSeptalComplex.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralSeptalComplex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralSeptalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralSeptalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralSeptalNucleusCaudalCaudodorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralSeptalNucleusCaudalCaudodorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralSeptalNucleusRostralRostroventralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralSeptalNucleusRostralRostroventralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralSeptalNucleusVentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralSeptalNucleusVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralSpinothalamicTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralSpinothalamicTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralStripOfStriatum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralStripOfStriatum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralTegmentalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralTegmentalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralTerminalNucleusOfTheAccessoryOpticTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralTerminalNucleusOfTheAccessoryOpticTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralVentricle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralVentricle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralVestibularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralVestibularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralVisualArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralVisualAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralVisualAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralVisualAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralVisualAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralVisualAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralVisualAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralVisualAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterodorsalTegmentalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterodorsalTegmentalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterointermediateArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterointermediateArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterointermediateAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterointermediateAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterointermediateAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterointermediateAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterointermediateAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterointermediateAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterointermediateAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterointermediateAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterointermediateAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterointermediateAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterointermediateAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterointermediateAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterolateralAnteriorVisualArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterolateralAnteriorVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterolateralAnteriorVisualAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterolateralAnteriorVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterolateralAnteriorVisualAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterolateralAnteriorVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterolateralAnteriorVisualAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterolateralAnteriorVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterolateralAnteriorVisualAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterolateralAnteriorVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterolateralAnteriorVisualAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterolateralAnteriorVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterolateralAnteriorVisualArealayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterolateralAnteriorVisualArealayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_layer6bIsocortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_layer6bIsocortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_linearNucleusOfTheMedulla.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_linearNucleusOfTheMedulla.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lingulaI.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lingulaI.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lingulaIGranularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lingulaIGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lingulaIMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lingulaIMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lingulaIPurkinjeLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lingulaIPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleII.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleII.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIIGranularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIIGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIII.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIII.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIIIGranularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIIIGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIIIMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIIIMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIIIPurkinjeLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIIIPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIIMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIIMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIIPurkinjeLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIIPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIV.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIV.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIVGranularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIVGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIVMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIVMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIVPurkinjeLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIVPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleV.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleV.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleVGranularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleVGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleVMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleVMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleVPurkinjeLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleVPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobulesIV-V.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobulesIV-V.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobulesIV-VGranularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobulesIV-VGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobulesIV-VMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobulesIV-VMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobulesIV-VPurkinjeLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobulesIV-VPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_locusCeruleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_locusCeruleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_longitudinalAssociationBundle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_longitudinalAssociationBundle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_magnocellularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_magnocellularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_magnocellularReticularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_magnocellularReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mainOlfactoryBulb.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mainOlfactoryBulb.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mainOlfactoryBulbGlomerularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mainOlfactoryBulbGlomerularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mainOlfactoryBulbGranuleLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mainOlfactoryBulbGranuleLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mainOlfactoryBulbInnerPlexiformLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mainOlfactoryBulbInnerPlexiformLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mainOlfactoryBulbMitralLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mainOlfactoryBulbMitralLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mainOlfactoryBulbOuterPlexiformLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mainOlfactoryBulbOuterPlexiformLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_majorIslandOfCalleja.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_majorIslandOfCalleja.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mammillaryBody.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mammillaryBody.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mammillaryPeduncle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mammillaryPeduncle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mammillaryRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mammillaryRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mammillotegmentalTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mammillotegmentalTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mammillothalamicTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mammillothalamicTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialAccesoryOculomotorNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialAccesoryOculomotorNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialAmygdalarNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialAmygdalarNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialAmygdalarNucleusAnterodorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialAmygdalarNucleusAnterodorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialAmygdalarNucleusAnteroventralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialAmygdalarNucleusAnteroventralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialAmygdalarNucleusPosterodorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialAmygdalarNucleusPosterodorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialAmygdalarNucleusPosterodorsalPartSublayerA.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialAmygdalarNucleusPosterodorsalPartSublayerA.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialAmygdalarNucleusPosterodorsalPartSublayerB.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialAmygdalarNucleusPosterodorsalPartSublayerB.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialAmygdalarNucleusPosterodorsalPartSublayerC.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialAmygdalarNucleusPosterodorsalPartSublayerC.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialAmygdalarNucleusPosteroventralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialAmygdalarNucleusPosteroventralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialCorticohypothalamicTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialCorticohypothalamicTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialForebrainBundle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialForebrainBundle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialForebrainBundleSystem.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialForebrainBundleSystem.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialGeniculateComplex.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialGeniculateComplex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialGeniculateComplexDorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialGeniculateComplexDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialGeniculateComplexMedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialGeniculateComplexMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialGeniculateComplexVentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialGeniculateComplexVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialGroupOfTheDorsalThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialGroupOfTheDorsalThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialHabenula.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialHabenula.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialLemniscus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialLemniscus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialLongitudinalFascicle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialLongitudinalFascicle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialMammillaryNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialMammillaryNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialMammillaryNucleusDorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialMammillaryNucleusDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialMammillaryNucleusLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialMammillaryNucleusLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialMammillaryNucleusMedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialMammillaryNucleusMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialMammillaryNucleusMedianPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialMammillaryNucleusMedianPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialMammillaryNucleusPosteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialMammillaryNucleusPosteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialPreopticArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialPreopticArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialPreopticNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialPreopticNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialPreopticNucleusCentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialPreopticNucleusCentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialPreopticNucleusLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialPreopticNucleusLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialPreopticNucleusMedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialPreopticNucleusMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialPretectalArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialPretectalArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialSeptalComplex.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialSeptalComplex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialSeptalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialSeptalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialTerminalNucleusOfTheAccessoryOpticTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialTerminalNucleusOfTheAccessoryOpticTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialVestibularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialVestibularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialVisualArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialVisualAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialVisualAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialVisualAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialVisualAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialVisualAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialVisualArealayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialVisualArealayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medianEminence.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medianEminence.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medianPreopticNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medianPreopticNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediodorsalNucleusOfThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediodorsalNucleusOfThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediodorsalNucleusOfTheThalamusCentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediodorsalNucleusOfTheThalamusCentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediodorsalNucleusOfTheThalamusLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediodorsalNucleusOfTheThalamusLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediodorsalNucleusOfTheThalamusMedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediodorsalNucleusOfTheThalamusMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialAnteriorVisualArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialAnteriorVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialAnteriorVisualAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialAnteriorVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialAnteriorVisualAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialAnteriorVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialAnteriorVisualAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialAnteriorVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialAnteriorVisualAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialAnteriorVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialAnteriorVisualAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialAnteriorVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialAnteriorVisualArealayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialAnteriorVisualArealayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialPosteriorVisualArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialPosteriorVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialPosteriorVisualAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialPosteriorVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialPosteriorVisualAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialPosteriorVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialPosteriorVisualAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialPosteriorVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialPosteriorVisualAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialPosteriorVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialPosteriorVisualAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialPosteriorVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialPosteriorVisualArealayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialPosteriorVisualArealayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medulla.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medulla.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medullaBehavioralStateRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medullaBehavioralStateRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medullaMotorRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medullaMotorRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medullaSensoryRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medullaSensoryRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medullaryReticularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medullaryReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medullaryReticularNucleusDorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medullaryReticularNucleusDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medullaryReticularNucleusVentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medullaryReticularNucleusVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrain.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrain.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainBehavioralStateRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainBehavioralStateRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainMotorRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainMotorRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainRapheNuclei.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainRapheNuclei.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainReticularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainReticularNucleusMagnocellularPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainReticularNucleusMagnocellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainReticularNucleusMagnocellularPartGeneral.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainReticularNucleusMagnocellularPartGeneral.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainReticularNucleusParvicellularPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainReticularNucleusParvicellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainReticularNucleusRetrorubralArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainReticularNucleusRetrorubralArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainSensoryRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainSensoryRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainTractOfTheTrigeminalNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainTractOfTheTrigeminalNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainTrigeminalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainTrigeminalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_middleCerebellarPeduncle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_middleCerebellarPeduncle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_middleThalamicCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_middleThalamicCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midlineGroupOfTheDorsalThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midlineGroupOfTheDorsalThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_motorNucleusOfTrigeminal.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_motorNucleusOfTrigeminal.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_motorRootOfTheTrigeminalNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_motorRootOfTheTrigeminalNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nigrostriatalTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nigrostriatalTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nigrothalamicFibers.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nigrothalamicFibers.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nodularFissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nodularFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nodulusX.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nodulusX.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nodulusXGranularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nodulusXGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nodulusXMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nodulusXMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nodulusXPurkinjeLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nodulusXPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusAccumbens.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusAccumbens.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusAmbiguus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusAmbiguus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusAmbiguusDorsalDivision.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusAmbiguusDorsalDivision.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusAmbiguusVentralDivision.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusAmbiguusVentralDivision.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusCircularis.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusCircularis.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusIncertus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusIncertus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusIntercalatus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusIntercalatus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfDarkschewitsch.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfDarkschewitsch.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfReuniens.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfReuniens.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfRoller.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfRoller.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheBrachiumOfTheInferiorColliculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheBrachiumOfTheInferiorColliculus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheLateralLemniscus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheLateralLemniscus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheLateralLemniscusDorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheLateralLemniscusDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheLateralLemniscusHorizontalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheLateralLemniscusHorizontalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheLateralLemniscusVentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheLateralLemniscusVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheLateralOlfactoryTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheLateralOlfactoryTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheLateralOlfactoryTractLayer3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheLateralOlfactoryTractLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheLateralOlfactoryTractLayers13.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheLateralOlfactoryTractLayers13.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheLateralOlfactoryTractMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheLateralOlfactoryTractMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheLateralOlfactoryTractPyramidalLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheLateralOlfactoryTractPyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheOpticTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheOpticTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfThePosteriorCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfThePosteriorCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheSolitaryTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheSolitaryTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheSolitaryTractCentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheSolitaryTractCentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheSolitaryTractCommissuralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheSolitaryTractCommissuralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheSolitaryTractGelatinousPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheSolitaryTractGelatinousPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheSolitaryTractLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheSolitaryTractLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheSolitaryTractMedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheSolitaryTractMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheTrapezoidBody.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheTrapezoidBody.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusPrepositus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusPrepositus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusRapheMagnus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusRapheMagnus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusRapheObscurus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusRapheObscurus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusRaphePallidus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusRaphePallidus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusRaphePontis.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusRaphePontis.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusSagulum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusSagulum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusX.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusX.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusY.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusY.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusZ.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusZ.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_oculomotorNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_oculomotorNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_oculomotorNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_oculomotorNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_olfactoryAreas.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_olfactoryAreas.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_olfactoryNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_olfactoryNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_olfactoryNerveLayerOfMainOlfactoryBulb.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_olfactoryNerveLayerOfMainOlfactoryBulb.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_olfactoryTubercle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_olfactoryTubercle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_olfactoryTubercleLayers13.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_olfactoryTubercleLayers13.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_olfactoryTubercleMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_olfactoryTubercleMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_olfactoryTuberclePolymorphLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_olfactoryTuberclePolymorphLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_olfactoryTuberclePyramidalLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_olfactoryTuberclePyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_olivaryPretectalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_olivaryPretectalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_olivocerebellarTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_olivocerebellarTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_opticChiasm.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_opticChiasm.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_opticNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_opticNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_opticRadiation.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_opticRadiation.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_opticTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_opticTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLateralPartLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLateralPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLateralPartLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLateralPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLateralPartLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLateralPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLateralPartLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLateralPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLateralPartLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLateralPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaMedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaMedialPartLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaMedialPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaMedialPartLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaMedialPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaMedialPartLayer2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaMedialPartLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaMedialPartLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaMedialPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaMedialPartLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaMedialPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaMedialPartLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaMedialPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaVentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaVentrolateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaVentrolateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaVentrolateralPartLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaVentrolateralPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaVentrolateralPartLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaVentrolateralPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaVentrolateralPartLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaVentrolateralPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaVentrolateralPartLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaVentrolateralPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaVentrolateralPartLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaVentrolateralPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pallidotegmentalFascicle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pallidotegmentalFascicle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pallidothalamicPathway.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pallidothalamicPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pallidum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pallidum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pallidumCaudalRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pallidumCaudalRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pallidumDorsalRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pallidumDorsalRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pallidumMedialRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pallidumMedialRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pallidumVentralRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pallidumVentralRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabigeminalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabigeminalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleusLateralDivision.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleusLateralDivision.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleusLateralDivisionCentralLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleusLateralDivisionCentralLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleusLateralDivisionDorsalLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleusLateralDivisionDorsalLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleusLateralDivisionExternalLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleusLateralDivisionExternalLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleusLateralDivisionSuperiorLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleusLateralDivisionSuperiorLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleusLateralDivisionVentralLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleusLateralDivisionVentralLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleusMedialDivision.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleusMedialDivision.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleusMedialDivisionExternalMedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleusMedialDivisionExternalMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleusMedialDivisionMedialMedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleusMedialDivisionMedialMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleusMedialDivisionVentralMedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleusMedialDivisionVentralMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paracentralNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paracentralNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parafascicularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parafascicularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parafloccularSulcus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parafloccularSulcus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraflocculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraflocculus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraflocculusGranularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraflocculusGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraflocculusMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraflocculusMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraflocculusPurkinjeLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraflocculusPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paragigantocellularReticularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paragigantocellularReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paragigantocellularReticularNucleusDorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paragigantocellularReticularNucleusDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paragigantocellularReticularNucleusLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paragigantocellularReticularNucleusLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paramedianLobule.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paramedianLobule.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paramedianLobuleGranularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paramedianLobuleGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paramedianLobuleMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paramedianLobuleMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paramedianLobulePurkinjeLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paramedianLobulePurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paramedianReticularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paramedianReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paramedianSulcus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paramedianSulcus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paranigralNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paranigralNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parapyramidalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parapyramidalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parapyramidalNucleusDeepPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parapyramidalNucleusDeepPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parapyramidalNucleusSuperficialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parapyramidalNucleusSuperficialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parasolitaryNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parasolitaryNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parastrialNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parastrialNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parasubiculum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parasubiculum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parasubiculumLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parasubiculumLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parasubiculumLayer2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parasubiculumLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parasubiculumLayer3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parasubiculumLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parasubthalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parasubthalamicNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parataenialNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parataenialNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paratrigeminalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paratrigeminalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paratrochlearNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paratrochlearNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusDescendingDivision.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusDescendingDivision.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusDescendingDivisionDorsalParvicellularPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusDescendingDivisionDorsalParvicellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusDescendingDivisionFornicealPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusDescendingDivisionFornicealPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusDescendingDivisionLateralParvicellularPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusDescendingDivisionLateralParvicellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusDescendingDivisionMedialParvicellularPartVentralZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusDescendingDivisionMedialParvicellularPartVentralZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusMagnocellularDivision.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusMagnocellularDivision.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusMagnocellularDivisionAnteriorMagnocellularPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusMagnocellularDivisionAnteriorMagnocellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusMagnocellularDivisionMedialMagnocellularPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusMagnocellularDivisionMedialMagnocellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusMagnocellularDivisionPosteriorMagnocellularPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusMagnocellularDivisionPosteriorMagnocellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusMagnocellularDivisionPosteriorMagnocellularPartLateralZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusMagnocellularDivisionPosteriorMagnocellularPartLateralZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusMagnocellularDivisionPosteriorMagnocellularPartMedialZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusMagnocellularDivisionPosteriorMagnocellularPartMedialZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusParvicellularDivision.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusParvicellularDivision.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusParvicellularDivisionAnteriorParvicellularPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusParvicellularDivisionAnteriorParvicellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusParvicellularDivisionMedialParvicellularPartDorsalZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusParvicellularDivisionMedialParvicellularPartDorsalZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusParvicellularDivisionPeriventricularPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusParvicellularDivisionPeriventricularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularNucleusOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parvicellularMotor5Nucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parvicellularMotor5Nucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parvicellularReticularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parvicellularReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pedunculopontineNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pedunculopontineNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_perforantPath.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_perforantPath.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_periaqueductalGray.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_periaqueductalGray.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_perifornicalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_perifornicalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_perihypoglossalNuclei.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_perihypoglossalNuclei.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_peripeduncularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_peripeduncularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_perireunensisNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_perireunensisNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_perirhinalArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_perirhinalArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_perirhinalAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_perirhinalAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_perirhinalAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_perirhinalAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_perirhinalAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_perirhinalAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_perirhinalAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_perirhinalAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_perirhinalAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_perirhinalAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_peritrigeminalZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_peritrigeminalZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_periventricularBundleOfTheHypothalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_periventricularBundleOfTheHypothalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_periventricularBundleOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_periventricularBundleOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_periventricularHypothalamicNucleusAnteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_periventricularHypothalamicNucleusAnteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_periventricularHypothalamicNucleusIntermediatePart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_periventricularHypothalamicNucleusIntermediatePart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_periventricularHypothalamicNucleusPosteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_periventricularHypothalamicNucleusPosteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_periventricularHypothalamicNucleusPreopticPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_periventricularHypothalamicNucleusPreopticPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_periventricularRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_periventricularRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_periventricularZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_periventricularZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pinealBody.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pinealBody.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pinealStalk.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pinealStalk.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_piriformArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_piriformArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_piriformAreaLayers13.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_piriformAreaLayers13.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_piriformAreaMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_piriformAreaMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_piriformAreaPolymorphLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_piriformAreaPolymorphLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_piriformAreaPyramidalLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_piriformAreaPyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_piriformamygdalarArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_piriformamygdalarArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_piriformamygdalarAreaLayers13.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_piriformamygdalarAreaLayers13.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_piriformamygdalarAreaMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_piriformamygdalarAreaMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_piriformamygdalarAreaPolymorphLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_piriformamygdalarAreaPolymorphLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_piriformamygdalarAreaPyramidalLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_piriformamygdalarAreaPyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pons.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pons.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ponsBehavioralStateRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ponsBehavioralStateRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ponsMotorRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ponsMotorRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ponsSensoryRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ponsSensoryRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pontineCentralGray.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pontineCentralGray.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pontineGray.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pontineGray.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pontineReticularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pontineReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pontineReticularNucleusCaudalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pontineReticularNucleusCaudalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pontineReticularNucleusVentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pontineReticularNucleusVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postcommissuralFornix.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postcommissuralFornix.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorAmygdalarNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorAmygdalarNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorAuditoryArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorAuditoryArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorAuditoryAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorAuditoryAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorAuditoryAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorAuditoryAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorAuditoryAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorAuditoryAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorAuditoryAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorAuditoryAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorAuditoryAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorAuditoryAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorAuditoryAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorAuditoryAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorComplexOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorComplexOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorHypothalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorHypothalamicNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorIntralaminarThalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorIntralaminarThalamicNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorLimitingNucleusOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorLimitingNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorParietalAssociationAreas.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorParietalAssociationAreas.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorParietalAssociationAreasLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorParietalAssociationAreasLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorParietalAssociationAreasLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorParietalAssociationAreasLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorParietalAssociationAreasLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorParietalAssociationAreasLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorParietalAssociationAreasLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorParietalAssociationAreasLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorParietalAssociationAreasLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorParietalAssociationAreasLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorParietalAssociationAreasLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorParietalAssociationAreasLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorPretectalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorPretectalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorSuperiorFissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorSuperiorFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorTriangularThalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorTriangularThalamicNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posterodorsalPreopticNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posterodorsalPreopticNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posterodorsalTegmentalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posterodorsalTegmentalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posterolateralFissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posterolateralFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posterolateralVisualArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posterolateralVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posterolateralVisualAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posterolateralVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posterolateralVisualAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posterolateralVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posterolateralVisualAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posterolateralVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posterolateralVisualAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posterolateralVisualAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posterolateralVisualAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posterolateralVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posterolateralVisualAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posterolateralVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteromedialVisualArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteromedialVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteromedialVisualAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteromedialVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteromedialVisualAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteromedialVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteromedialVisualAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteromedialVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteromedialVisualAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteromedialVisualAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteromedialVisualAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteromedialVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteromedialVisualAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteromedialVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postpiriformTransitionArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postpiriformTransitionArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postpiriformTransitionAreaLayers1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postpiriformTransitionAreaLayers1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postpiriformTransitionAreaLayers13.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postpiriformTransitionAreaLayers13.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postpiriformTransitionAreaLayers2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postpiriformTransitionAreaLayers2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postpiriformTransitionAreaLayers3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postpiriformTransitionAreaLayers3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postrhinalArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postrhinalArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postrhinalAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postrhinalAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postrhinalAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postrhinalAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postrhinalAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postrhinalAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postrhinalAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postrhinalAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postrhinalAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postrhinalAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postrhinalAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postrhinalAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postsubiculum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postsubiculum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postsubiculumLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postsubiculumLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postsubiculumLayer2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postsubiculumLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postsubiculumLayer3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postsubiculumLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_precentralFissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_precentralFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_precommissuralFornixDiagonalBand.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_precommissuralFornixDiagonalBand.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_precommissuralFornixGeneral.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_precommissuralFornixGeneral.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_precommissuralNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_precommissuralNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_preculminateFissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_preculminateFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prelimbicArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prelimbicArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prelimbicAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prelimbicAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prelimbicAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prelimbicAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prelimbicAreaLayer2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prelimbicAreaLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prelimbicAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prelimbicAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prelimbicAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prelimbicAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prelimbicAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prelimbicAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_premammillaryCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_premammillaryCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_preopticCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_preopticCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_preparasubthalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_preparasubthalamicNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prepyramidalFissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prepyramidalFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_presubiculum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_presubiculum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_presubiculumLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_presubiculumLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_presubiculumLayer2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_presubiculumLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_presubiculumLayer3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_presubiculumLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pretectalRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pretectalRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryAuditoryArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryAuditoryArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryAuditoryAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryAuditoryAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryAuditoryAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryAuditoryAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryAuditoryAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryAuditoryAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryAuditoryAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryAuditoryAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryAuditoryAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryAuditoryAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryAuditoryAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryAuditoryAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryFissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryMotorArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryMotorArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryMotorAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryMotorAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryMotorAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryMotorAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryMotorAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryMotorAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryMotorAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryMotorAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryMotorAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryMotorAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaBarrelField.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaBarrelField.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaBarrelFieldLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaBarrelFieldLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaBarrelFieldLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaBarrelFieldLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaBarrelFieldLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaBarrelFieldLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaBarrelFieldLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaBarrelFieldLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaBarrelFieldLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaBarrelFieldLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaBarrelFieldLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaBarrelFieldLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLowerLimb.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLowerLimb.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLowerLimbLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLowerLimbLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLowerLimbLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLowerLimbLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLowerLimbLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLowerLimbLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLowerLimbLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLowerLimbLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLowerLimbLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLowerLimbLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLowerLimbLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLowerLimbLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaMouth.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaMouth.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaMouthLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaMouthLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaMouthLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaMouthLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaMouthLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaMouthLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaMouthLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaMouthLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaMouthLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaMouthLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaMouthLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaMouthLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaNose.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaNose.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaNoseLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaNoseLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaNoseLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaNoseLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaNoseLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaNoseLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaNoseLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaNoseLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaNoseLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaNoseLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaNoseLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaNoseLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaTrunk.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaTrunk.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaTrunkLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaTrunkLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaTrunkLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaTrunkLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaTrunkLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaTrunkLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaTrunkLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaTrunkLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaTrunkLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaTrunkLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaTrunkLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaTrunkLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUnassigned.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUnassigned.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUnassignedLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUnassignedLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUnassignedLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUnassignedLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUnassignedLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUnassignedLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUnassignedLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUnassignedLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUnassignedLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUnassignedLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUnassignedLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUnassignedLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUpperLimb.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUpperLimb.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUpperLimbLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUpperLimbLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUpperLimbLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUpperLimbLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUpperLimbLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUpperLimbLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUpperLimbLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUpperLimbLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUpperLimbLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUpperLimbLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUpperLimbLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUpperLimbLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryVisualArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryVisualAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryVisualAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryVisualAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryVisualAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryVisualAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryVisualAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryVisualAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_principalMammillaryTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_principalMammillaryTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_principalSensoryNucleusOfTheTrigeminal.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_principalSensoryNucleusOfTheTrigeminal.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_propriohypothalamicPathways.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_propriohypothalamicPathways.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_propriohypothalamicPathwaysDorsal.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_propriohypothalamicPathwaysDorsal.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_propriohypothalamicPathwaysLateral.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_propriohypothalamicPathwaysLateral.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_propriohypothalamicPathwaysMedial.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_propriohypothalamicPathwaysMedial.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_propriohypothalamicPathwaysVentral.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_propriohypothalamicPathwaysVentral.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prosubiculum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prosubiculum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prosubiculumDorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prosubiculumDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prosubiculumDorsalPartMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prosubiculumDorsalPartMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prosubiculumDorsalPartPyramidalLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prosubiculumDorsalPartPyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prosubiculumDorsalPartStratumRadiatum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prosubiculumDorsalPartStratumRadiatum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prosubiculumVentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prosubiculumVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prosubiculumVentralPartMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prosubiculumVentralPartMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prosubiculumVentralPartPyramidalLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prosubiculumVentralPartPyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prosubiculumVentralPartStratumRadiatum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prosubiculumVentralPartStratumRadiatum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pyramid.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pyramid.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pyramidalDecussation.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pyramidalDecussation.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pyramusVIII.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pyramusVIII.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pyramusVIIIGranularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pyramusVIIIGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pyramusVIIIMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pyramusVIIIMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pyramusVIIIPurkinjeLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pyramusVIIIPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_redNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_redNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_reticularNucleusOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_reticularNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_reticulocerebellarTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_reticulocerebellarTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retina.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retina.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retriculospinalTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retriculospinalTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retriculospinalTractLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retriculospinalTractLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retriculospinalTractMedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retriculospinalTractMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrochiasmaticArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrochiasmaticArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retroethmoidNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retroethmoidNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrohippocampalRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrohippocampalRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retroparafascicularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retroparafascicularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaDorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaDorsalPartLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaDorsalPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaDorsalPartLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaDorsalPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaDorsalPartLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaDorsalPartLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaDorsalPartLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaDorsalPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaDorsalPartLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaDorsalPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaDorsalPartLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaDorsalPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaLateralAgranularPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaLateralAgranularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaLateralAgranularPartLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaLateralAgranularPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaLateralAgranularPartLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaLateralAgranularPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaLateralAgranularPartLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaLateralAgranularPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaLateralAgranularPartLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaLateralAgranularPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaLateralAgranularPartLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaLateralAgranularPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaVentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaVentralPartLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaVentralPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaVentralPartLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaVentralPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaVentralPartLayer2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaVentralPartLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaVentralPartLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaVentralPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaVentralPartLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaVentralPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaVentralPartLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaVentralPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rhinalFissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rhinalFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rhinalIncisure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rhinalIncisure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rhinocele.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rhinocele.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rhomboidNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rhomboidNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_root.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_root.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostralLinearNucleusRaphe.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostralLinearNucleusRaphe.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralLateralVisualArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralLateralVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralLateralVisualAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralLateralVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralLateralVisualAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralLateralVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralLateralVisualAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralLateralVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralLateralVisualAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralLateralVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralLateralVisualAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralLateralVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralLateralVisualArealayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralLateralVisualArealayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralVisualArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rubroreticularTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rubroreticularTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rubrospinalTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rubrospinalTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_secondaryFissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_secondaryFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_secondaryMotorArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_secondaryMotorArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_secondaryMotorAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_secondaryMotorAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_secondaryMotorAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_secondaryMotorAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_secondaryMotorAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_secondaryMotorAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_secondaryMotorAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_secondaryMotorAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_secondaryMotorAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_secondaryMotorAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_sensoryRootOfTheTrigeminalNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_sensoryRootOfTheTrigeminalNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_septofimbrialNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_septofimbrialNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_septohippocampalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_septohippocampalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_simpleFissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_simpleFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_simpleLobule.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_simpleLobule.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_simpleLobuleGranularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_simpleLobuleGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_simpleLobuleMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_simpleLobuleMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_simpleLobulePurkinjeLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_simpleLobulePurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_solitaryTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_solitaryTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatomotorAreas.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatomotorAreas.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatomotorAreasLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatomotorAreasLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatomotorAreasLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatomotorAreasLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatomotorAreasLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatomotorAreasLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatomotorAreasLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatomotorAreasLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatomotorAreasLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatomotorAreasLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatosensoryAreas.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatosensoryAreas.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatosensoryAreasLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatosensoryAreasLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatosensoryAreasLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatosensoryAreasLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatosensoryAreasLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatosensoryAreasLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatosensoryAreasLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatosensoryAreasLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatosensoryAreasLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatosensoryAreasLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatosensoryAreasLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatosensoryAreasLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinalNucleusOfTheTrigeminalCaudalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinalNucleusOfTheTrigeminalCaudalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinalNucleusOfTheTrigeminalInterpolarPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinalNucleusOfTheTrigeminalInterpolarPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinalNucleusOfTheTrigeminalOralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinalNucleusOfTheTrigeminalOralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinalNucleusOfTheTrigeminalOralPartCaudalDorsomedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinalNucleusOfTheTrigeminalOralPartCaudalDorsomedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinalNucleusOfTheTrigeminalOralPartMiddleDorsomedialPartDorsalZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinalNucleusOfTheTrigeminalOralPartMiddleDorsomedialPartDorsalZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinalNucleusOfTheTrigeminalOralPartMiddleDorsomedialPartVentralZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinalNucleusOfTheTrigeminalOralPartMiddleDorsomedialPartVentralZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinalNucleusOfTheTrigeminalOralPartRostralDorsomedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinalNucleusOfTheTrigeminalOralPartRostralDorsomedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinalNucleusOfTheTrigeminalOralPartVentrolateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinalNucleusOfTheTrigeminalOralPartVentrolateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinalTractOfTheTrigeminalNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinalTractOfTheTrigeminalNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinalVestibularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinalVestibularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinocerebellarTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinocerebellarTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinocervicalTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinocervicalTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinohypothalamicPathway.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinohypothalamicPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinoolivaryPathway.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinoolivaryPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinoreticularPathway.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinoreticularPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinotectalPathway.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinotectalPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinotelenchephalicPathway.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinotelenchephalicPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinothalamicTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinothalamicTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinovestibularPathway.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinovestibularPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_striaMedullaris.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_striaMedullaris.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_striaTerminalis.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_striaTerminalis.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_striatonigralPathway.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_striatonigralPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_striatum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_striatum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_striatumDorsalRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_striatumDorsalRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_striatumVentralRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_striatumVentralRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_striatumlikeAmygdalarNuclei.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_striatumlikeAmygdalarNuclei.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subceruleusNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subceruleusNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subcommissuralOrgan.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subcommissuralOrgan.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subependymalZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subependymalZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subfornicalOrgan.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subfornicalOrgan.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subgeniculateNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subgeniculateNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subiculum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subiculum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subiculumDorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subiculumDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subiculumDorsalPartMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subiculumDorsalPartMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subiculumDorsalPartPyramidalLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subiculumDorsalPartPyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subiculumDorsalPartStratumRadiatum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subiculumDorsalPartStratumRadiatum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subiculumVentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subiculumVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subiculumVentralPartMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subiculumVentralPartMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subiculumVentralPartPyramidalLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subiculumVentralPartPyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subiculumVentralPartStratumRadiatum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subiculumVentralPartStratumRadiatum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_sublaterodorsalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_sublaterodorsalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_submedialNucleusOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_submedialNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subparafascicularArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subparafascicularArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subparafascicularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subparafascicularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subparafascicularNucleusMagnocellularPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subparafascicularNucleusMagnocellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subparafascicularNucleusParvicellularPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subparafascicularNucleusParvicellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subparaventricularZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subparaventricularZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_substantiaInnominata.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_substantiaInnominata.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_substantiaNigraCompactPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_substantiaNigraCompactPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_substantiaNigraLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_substantiaNigraLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_substantiaNigraReticularPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_substantiaNigraReticularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subthalamicFascicle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subthalamicFascicle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subthalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subthalamicNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorCentralNucleusRaphe.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorCentralNucleusRaphe.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorCentralNucleusRapheLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorCentralNucleusRapheLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorCentralNucleusRapheMedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorCentralNucleusRapheMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorCerebelarPeduncles.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorCerebelarPeduncles.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorCerebellarPeduncleDecussation.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorCerebellarPeduncleDecussation.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusMotorRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusMotorRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusMotorRelatedDeepGrayLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusMotorRelatedDeepGrayLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusMotorRelatedDeepWhiteLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusMotorRelatedDeepWhiteLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusMotorRelatedIntermediateGrayLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusMotorRelatedIntermediateGrayLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusMotorRelatedIntermediateGrayLayerSublayerA.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusMotorRelatedIntermediateGrayLayerSublayerA.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusMotorRelatedIntermediateGrayLayerSublayerB.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusMotorRelatedIntermediateGrayLayerSublayerB.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusMotorRelatedIntermediateGrayLayerSublayerC.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusMotorRelatedIntermediateGrayLayerSublayerC.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusMotorRelatedIntermediateWhiteLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusMotorRelatedIntermediateWhiteLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusOpticLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusOpticLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusSensoryRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusSensoryRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusSuperficialGrayLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusSuperficialGrayLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusZonalLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusZonalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorOlivaryComplex.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorOlivaryComplex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorOlivaryComplexLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorOlivaryComplexLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorOlivaryComplexMedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorOlivaryComplexMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorOlivaryComplexPeriolivaryRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorOlivaryComplexPeriolivaryRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorSalivatoryNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorSalivatoryNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorVestibularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorVestibularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supplementalSomatosensoryArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supplementalSomatosensoryArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supplementalSomatosensoryAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supplementalSomatosensoryAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supplementalSomatosensoryAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supplementalSomatosensoryAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supplementalSomatosensoryAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supplementalSomatosensoryAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supplementalSomatosensoryAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supplementalSomatosensoryAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supplementalSomatosensoryAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supplementalSomatosensoryAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supplementalSomatosensoryAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supplementalSomatosensoryAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supracallosalCerebralWhiteMatter.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supracallosalCerebralWhiteMatter.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_suprachiasmaticNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_suprachiasmaticNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_suprachiasmaticPreopticNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_suprachiasmaticPreopticNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_suprageniculateNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_suprageniculateNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supragenualNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supragenualNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supramammillaryDecussation.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supramammillaryDecussation.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supramammillaryNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supramammillaryNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supramammillaryNucleusLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supramammillaryNucleusLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supramammillaryNucleusMedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supramammillaryNucleusMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supraoculomotorPeriaqueductalGray.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supraoculomotorPeriaqueductalGray.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supraopticCommissures.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supraopticCommissures.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supraopticCommissuresAnterior.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supraopticCommissuresAnterior.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supraopticCommissuresDorsal.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supraopticCommissuresDorsal.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supraopticCommissuresVentral.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supraopticCommissuresVentral.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supraopticNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supraopticNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supratrigeminalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supratrigeminalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTecta.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTecta.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaDorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaDorsalPartLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaDorsalPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaDorsalPartLayer2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaDorsalPartLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaDorsalPartLayer3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaDorsalPartLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaDorsalPartLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaDorsalPartLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaDorsalPartLayers14.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaDorsalPartLayers14.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaVentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaVentralPartLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaVentralPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaVentralPartLayer2.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaVentralPartLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaVentralPartLayer3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaVentralPartLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaVentralPartLayers13.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaVentralPartLayers13.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_tectospinalPathway.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_tectospinalPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_tectothalamicPathway.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_tectothalamicPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_tegmentalReticularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_tegmentalReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_temporalAssociationAreas.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_temporalAssociationAreas.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_temporalAssociationAreasLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_temporalAssociationAreasLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_temporalAssociationAreasLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_temporalAssociationAreasLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_temporalAssociationAreasLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_temporalAssociationAreasLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_temporalAssociationAreasLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_temporalAssociationAreasLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_temporalAssociationAreasLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_temporalAssociationAreasLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_temporalAssociationAreasLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_temporalAssociationAreasLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_terminalNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_terminalNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_thalamicPeduncles.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_thalamicPeduncles.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_thalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_thalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_thalamusPolymodalAssociationCortexRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_thalamusPolymodalAssociationCortexRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_thalamusRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_thalamusRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_thalamusSensorymotorCortexRelated.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_thalamusSensorymotorCortexRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_thirdVentricle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_thirdVentricle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_trapezoidBody.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_trapezoidBody.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_triangularNucleusOfSeptum.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_triangularNucleusOfSeptum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_trigeminalNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_trigeminalNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_trigeminocerebellarTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_trigeminocerebellarTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_trochlearNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_trochlearNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_trochlearNerveDecussation.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_trochlearNerveDecussation.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_trochlearNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_trochlearNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_tuberalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_tuberalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_tuberomammillaryNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_tuberomammillaryNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_tuberomammillaryNucleusDorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_tuberomammillaryNucleusDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_tuberomammillaryNucleusVentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_tuberomammillaryNucleusVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_uncinateFascicle.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_uncinateFascicle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_uvulaIX.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_uvulaIX.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_uvulaIXGranularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_uvulaIXGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_uvulaIXMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_uvulaIXMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_uvulaIXPurkinjeLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_uvulaIXPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_vagusNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_vagusNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_vascularOrganOfTheLaminaTerminalis.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_vascularOrganOfTheLaminaTerminalis.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralAnteriorlateralComplexOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralAnteriorlateralComplexOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralAuditoryArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralAuditoryArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralAuditoryAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralAuditoryAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralAuditoryAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralAuditoryAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralAuditoryAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralAuditoryAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralAuditoryAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralAuditoryAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralAuditoryAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralAuditoryAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralAuditoryAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralAuditoryAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralCochlearNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralCochlearNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralCommissureOfTheSpinalCord.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralCommissureOfTheSpinalCord.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralGroupOfTheDorsalThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralGroupOfTheDorsalThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralHippocampalCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralHippocampalCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralMedialNucleusOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralMedialNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralPartOfTheLateralGeniculateComplex.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralPartOfTheLateralGeniculateComplex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralPartOfTheLateralGeniculateComplexLateralZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralPartOfTheLateralGeniculateComplexLateralZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralPartOfTheLateralGeniculateComplexMedialZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralPartOfTheLateralGeniculateComplexMedialZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralPosteriorComplexOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralPosteriorComplexOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralPosterolateralNucleusOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralPosterolateralNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralPosterolateralNucleusOfTheThalamusParvicellularPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralPosterolateralNucleusOfTheThalamusParvicellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralPosteromedialNucleusOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralPosteromedialNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralPosteromedialNucleusOfTheThalamusParvicellularPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralPosteromedialNucleusOfTheThalamusParvicellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralPremammillaryNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralPremammillaryNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralRoots.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralRoots.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralSpinocerebellarTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralSpinocerebellarTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralSpinothalamicTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralSpinothalamicTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralTegmentalArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralTegmentalArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralTegmentalDecussation.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralTegmentalDecussation.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralTegmentalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralTegmentalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventricularSystems.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventricularSystems.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventrolateralHypothalamicTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventrolateralHypothalamicTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventrolateralPreopticNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventrolateralPreopticNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventromedialHypothalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventromedialHypothalamicNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventromedialHypothalamicNucleusAnteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventromedialHypothalamicNucleusAnteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventromedialHypothalamicNucleusCentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventromedialHypothalamicNucleusCentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventromedialHypothalamicNucleusDorsomedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventromedialHypothalamicNucleusDorsomedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventromedialHypothalamicNucleusVentrolateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventromedialHypothalamicNucleusVentrolateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventromedialPreopticNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventromedialPreopticNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_vermalRegions.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_vermalRegions.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_vestibularNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_vestibularNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_vestibularNuclei.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_vestibularNuclei.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_vestibulocerebellarNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_vestibulocerebellarNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_vestibulocochlearNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_vestibulocochlearNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_vestibulospinalPathway.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_vestibulospinalPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visceralArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visceralArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visceralAreaLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visceralAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visceralAreaLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visceralAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visceralAreaLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visceralAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visceralAreaLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visceralAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visceralAreaLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visceralAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visceralAreaLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visceralAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visualAreas.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visualAreas.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visualAreasLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visualAreasLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visualAreasLayer2-3.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visualAreasLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visualAreasLayer4.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visualAreasLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visualAreasLayer5.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visualAreasLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visualAreasLayer6a.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visualAreasLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visualAreasLayer6b.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visualAreasLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_vomeronasalNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_vomeronasalNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_xiphoidThalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_xiphoidThalamicNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_zonaIncerta.jsonld
+++ b/instances/latest/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_zonaIncerta.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA1.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA1.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA10.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA10.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA11.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA11.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA12.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA12.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA13.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA13.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA14.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA14.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA15.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA15.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA16.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA16.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA17.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA17.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA18.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA18.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA19.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA19.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA2.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA2.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA20.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA20.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA21.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA21.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA22.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA22.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA23.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA23.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA24.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA24.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA25.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA25.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA26.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA26.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA27.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA27.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA28.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA28.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA29.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA29.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA3.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA3.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA30.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA30.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA31.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA31.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA32.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA32.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA33.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA33.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA34.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA34.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA35.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA35.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA36.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA36.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA37.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA37.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA38.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA38.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA39.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA39.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA4.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA4.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA40.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA40.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA41.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA41.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA42.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA42.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA43.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA43.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA44.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA44.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA45.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA45.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA46.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA46.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA47.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA47.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA48.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA48.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA5.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA5.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA52.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA52.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA6.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA6.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA7.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA7.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA8.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA8.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA8a.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA8a.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA9.jsonld
+++ b/instances/latest/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA9.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/latest/parcellationEntityVersions/DWMA_2018/DWMA_2018_anteriorSegementOfArcuateFasciculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/DWMA_2018/DWMA_2018_anteriorSegementOfArcuateFasciculus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -34,7 +33,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/DWMA_2018/DWMA_2018_corticospinalTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/DWMA_2018/DWMA_2018_corticospinalTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -34,7 +33,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/DWMA_2018/DWMA_2018_directSegementOfArcuateFasciculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/DWMA_2018/DWMA_2018_directSegementOfArcuateFasciculus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -34,7 +33,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/DWMA_2018/DWMA_2018_fornix.jsonld
+++ b/instances/latest/parcellationEntityVersions/DWMA_2018/DWMA_2018_fornix.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -34,7 +33,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/DWMA_2018/DWMA_2018_inferiorFronto-occipitalFasciculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/DWMA_2018/DWMA_2018_inferiorFronto-occipitalFasciculus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -34,7 +33,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/DWMA_2018/DWMA_2018_inferiorLongitudinalFasciculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/DWMA_2018/DWMA_2018_inferiorLongitudinalFasciculus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -34,7 +33,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/DWMA_2018/DWMA_2018_longCingulateFibres.jsonld
+++ b/instances/latest/parcellationEntityVersions/DWMA_2018/DWMA_2018_longCingulateFibres.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -34,7 +33,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/DWMA_2018/DWMA_2018_posteriorSegementOfArcuateFasciculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/DWMA_2018/DWMA_2018_posteriorSegementOfArcuateFasciculus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -34,7 +33,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/DWMA_2018/DWMA_2018_shortCingulateFibres.jsonld
+++ b/instances/latest/parcellationEntityVersions/DWMA_2018/DWMA_2018_shortCingulateFibres.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -34,7 +33,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/DWMA_2018/DWMA_2018_temporalCingulateFibres.jsonld
+++ b/instances/latest/parcellationEntityVersions/DWMA_2018/DWMA_2018_temporalCingulateFibres.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -34,7 +33,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/DWMA_2018/DWMA_2018_uncinateFasciculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/DWMA_2018/DWMA_2018_uncinateFasciculus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -34,7 +33,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-1_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-1_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-25_PM-v16.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-25_PM-v16.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-33_PM-v16.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-33_PM-v16.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-3a_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-3a_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-3b_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-3b_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-44_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-44_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-45_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-45_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-4a_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-4a_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-4p_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-4p_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-5Ci_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-5Ci_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-5L_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-5L_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-5M_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-5M_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-7A_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-7A_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-7M_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-7M_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-7PC_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-7PC_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-7P_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-7P_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-FG1_PM-v1.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-FG1_PM-v1.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-FG2_PM-v1.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-FG2_PM-v1.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-FG3_PM-v6.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-FG3_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-FG4_PM-v6.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-FG4_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-Fo1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-Fo1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-Fo2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-Fo2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-Fo3_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-Fo3_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-Fp1_PM-v2.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-Fp1_PM-v2.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-Fp2_PM-v2.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-Fp2_PM-v2.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-Id1_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-Id1_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-Ig1_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-Ig1_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-Ig2_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-Ig2_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-OP1_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-OP1_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-OP2_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-OP2_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-OP3_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-OP3_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-OP4_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-OP4_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-PF_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-PF_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-PFcm_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-PFcm_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-PFm_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-PFm_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-PFop_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-PFop_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-PFt_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-PFt_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-PGa_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-PGa_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-PGp_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-PGp_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-TE-1.0_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-TE-1.0_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-TE-1.1_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-TE-1.1_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-TE-1.2_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-TE-1.2_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-TE-3_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-TE-3_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hIP1_PM-v6.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hIP1_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hIP2_PM-v6.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hIP2_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hIP3_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hIP3_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hOc1_PM-v2.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hOc1_PM-v2.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hOc2_PM-v2.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hOc2_PM-v2.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hOc3d_PM-v2.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hOc3d_PM-v2.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hOc3v_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hOc3v_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hOc4d_PM-v2.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hOc4d_PM-v2.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hOc4la_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hOc4la_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hOc4lp_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hOc4lp_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hOc4v_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hOc4v_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hOc5_PM-v2.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hOc5_PM-v2.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-s24_PM-v16.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-s24_PM-v16.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-s32_PM-v16.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-s32_PM-v16.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_CA1_PM-v11b.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_CA1_PM-v11b.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_CA2_PM-v11b.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_CA2_PM-v11b.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_CA3_PM-v11b.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_CA3_PM-v11b.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_CM_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_CM_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Ch-123_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Ch-123_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Ch-4_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Ch-4_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_DG_PM-v11b.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_DG_PM-v11b.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Dorsal-Dentate-Nucleus_PM-v6.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Dorsal-Dentate-Nucleus_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Entorhinal-Cortex_PM-v11b.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Entorhinal-Cortex_PM-v11b.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Fastigial-Nucleus_PM-v6.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Fastigial-Nucleus_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_HATA_PM-v11b.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_HATA_PM-v11b.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_IF_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_IF_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Interposed-Nucleus_PM-v6.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Interposed-Nucleus_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_LB_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_LB_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_MF_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_MF_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_SF_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_SF_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Subiculum_PM-v11b.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Subiculum_PM-v11b.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_VTM_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_VTM_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Ventral-Dentate-Nucleus_PM-v6.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Ventral-Dentate-Nucleus_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-1_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-1_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-25_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-25_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-2_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-2_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-33_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-33_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-3a_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-3a_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-3b_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-3b_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-44_PM-v7.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-44_PM-v7.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-45_PM-v7.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-45_PM-v7.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-4a_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-4a_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-4p_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-4p_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-5Ci_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-5Ci_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-5L_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-5L_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-5M_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-5M_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-6d1_PM-v4.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-6d1_PM-v4.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-6d2_PM-v4.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-6d2_PM-v4.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-6d3_PM-v4.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-6d3_PM-v4.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-6ma_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-6ma_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-6mp_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-6mp_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-7A_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-7A_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-7M_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-7M_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-7PC_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-7PC_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-7P_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-7P_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-FG1_PM-v1.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-FG1_PM-v1.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-FG2_PM-v1.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-FG2_PM-v1.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-FG3_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-FG3_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-FG4_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-FG4_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Fo1_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Fo1_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Fo2_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Fo2_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Fo3_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Fo3_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Fo4_PM-v2.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Fo4_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Fo5_PM-v2.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Fo5_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Fo6_PM-v2.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Fo6_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Fo7_PM-v2.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Fo7_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Fp1_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Fp1_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Fp2_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Fp2_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Ia_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Ia_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Id1_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Id1_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Id2_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Id2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Id3_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Id3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Id4_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Id4_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Id5_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Id5_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Id6_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Id6_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Id7_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Id7_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Ig1_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Ig1_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Ig2_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Ig2_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Ig3_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Ig3_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-OP1_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-OP1_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-OP2_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-OP2_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-OP3_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-OP3_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-OP4_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-OP4_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-OP8_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-OP8_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-OP9_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-OP9_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-PF_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-PF_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-PFcm_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-PFcm_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-PFm_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-PFm_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-PFop_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-PFop_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-PFt_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-PFt_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-PGa_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-PGa_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-PGp_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-PGp_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-STS1_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-STS1_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-STS2_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-STS2_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-TE-1.0_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-TE-1.0_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-TE-1.1_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-TE-1.1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-TE-1.2_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-TE-1.2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-TE-3_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-TE-3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hIP1_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hIP1_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hIP2_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hIP2_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hIP3_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hIP3_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hIP4_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hIP4_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hIP5_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hIP5_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hIP6_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hIP6_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hIP7_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hIP7_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hIP8_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hIP8_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hOc1_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hOc1_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hOc2_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hOc2_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hOc3d_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hOc3d_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hOc3v_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hOc3v_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hOc4d_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hOc4d_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hOc4la_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hOc4la_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hOc4lp_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hOc4lp_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hOc4v_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hOc4v_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hOc5_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hOc5_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hOc6_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hOc6_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hPO1_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hPO1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-p24ab_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-p24ab_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-p24c_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-p24c_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-p32_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-p32_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-s24_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-s24_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-s32_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-s32_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_CA_PM-v11.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_CA_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_CM_PM-v6.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_CM_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Ch-123_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Ch-123_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Ch-4_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Ch-4_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_DG_PM-v11.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_DG_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Dorsal-Dentate-Nucleus_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Dorsal-Dentate-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Entorhinal-Cortex_PM-v11.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Entorhinal-Cortex_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Fastigial-Nucleus_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Fastigial-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_HATA_PM-v11.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_HATA_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_IF_PM-v6.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_IF_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Interposed-Nucleus_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Interposed-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_LB_PM-v6.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_LB_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_MF_PM-v6.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_MF_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_SF_PM-v6.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_SF_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Subiculum_PM-v11.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Subiculum_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_VTM_PM-v6.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_VTM_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Ventral-Dentate-Nucleus_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Ventral-Dentate-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-1_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-1_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-25_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-25_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-2_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-2_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-33_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-33_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-3a_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-3a_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-3b_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-3b_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-44_PM-v7.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-44_PM-v7.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-45_PM-v7.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-45_PM-v7.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-4a_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-4a_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-4p_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-4p_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-5Ci_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-5Ci_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-5L_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-5L_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-5M_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-5M_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-6d1_PM-v4.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-6d1_PM-v4.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-6d2_PM-v4.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-6d2_PM-v4.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-6d3_PM-v4.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-6d3_PM-v4.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-6ma_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-6ma_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-6mp_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-6mp_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-7A_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-7A_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-7M_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-7M_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-7PC_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-7PC_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-7P_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-7P_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-FG1_PM-v1.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-FG1_PM-v1.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-FG2_PM-v1.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-FG2_PM-v1.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-FG3_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-FG3_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-FG4_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-FG4_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Fo1_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Fo1_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Fo2_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Fo2_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Fo3_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Fo3_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Fo4_PM-v2.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Fo4_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Fo5_PM-v2.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Fo5_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Fo6_PM-v2.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Fo6_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Fo7_PM-v2.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Fo7_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Fp1_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Fp1_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Fp2_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Fp2_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Ia_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Ia_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Id1_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Id1_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Id2_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Id2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Id3_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Id3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Id4_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Id4_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Id5_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Id5_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Id6_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Id6_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Id7_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Id7_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Ig1_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Ig1_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Ig2_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Ig2_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Ig3_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Ig3_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-OP1_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-OP1_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-OP2_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-OP2_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-OP3_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-OP3_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-OP4_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-OP4_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-OP8_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-OP8_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-OP9_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-OP9_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-PF_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-PF_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-PFcm_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-PFcm_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-PFm_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-PFm_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-PFop_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-PFop_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-PFt_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-PFt_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-PGa_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-PGa_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-PGp_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-PGp_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-STS1_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-STS1_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-STS2_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-STS2_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-TE-1.0_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-TE-1.0_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-TE-1.1_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-TE-1.1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-TE-1.2_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-TE-1.2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-TE-3_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-TE-3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hIP1_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hIP1_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hIP2_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hIP2_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hIP3_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hIP3_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hIP4_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hIP4_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hIP5_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hIP5_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hIP6_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hIP6_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hIP7_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hIP7_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hIP8_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hIP8_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hOc1_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hOc1_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hOc2_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hOc2_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hOc3d_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hOc3d_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hOc3v_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hOc3v_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hOc4d_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hOc4d_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hOc4la_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hOc4la_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hOc4lp_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hOc4lp_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hOc4v_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hOc4v_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hOc5_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hOc5_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hOc6_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hOc6_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hPO1_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hPO1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-p24ab_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-p24ab_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-p24c_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-p24c_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-p32_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-p32_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-s24_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-s24_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-s32_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-s32_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_CA_PM-v11.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_CA_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_CM_PM-v6.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_CM_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Ch-123_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Ch-123_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Ch-4_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Ch-4_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_DG_PM-v11.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_DG_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Dorsal-Dentate-Nucleus_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Dorsal-Dentate-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Entorhinal-Cortex_PM-v11.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Entorhinal-Cortex_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Fastigial-Nucleus_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Fastigial-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_HATA_PM-v11.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_HATA_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_IF_PM-v6.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_IF_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Interposed-Nucleus_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Interposed-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_LB_PM-v6.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_LB_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_MF_PM-v6.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_MF_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_SF_PM-v6.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_SF_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Subiculum_PM-v11.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Subiculum_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_VTM_PM-v6.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_VTM_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Ventral-Dentate-Nucleus_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Ventral-Dentate-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-1_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-1_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-25_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-25_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-2_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-2_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-33_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-33_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-3a_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-3a_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-3b_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-3b_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-44_PM-v7.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-44_PM-v7.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-45_PM-v7.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-45_PM-v7.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-4a_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-4a_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-4p_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-4p_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-5Ci_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-5Ci_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-5L_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-5L_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-5M_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-5M_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-6d1_PM-v4.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-6d1_PM-v4.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-6d2_PM-v4.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-6d2_PM-v4.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-6d3_PM-v4.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-6d3_PM-v4.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-6ma_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-6ma_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-6mp_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-6mp_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-7A_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-7A_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-7PC_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-7PC_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-7P_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-7P_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-FG1_PM-v1.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-FG1_PM-v1.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-FG2_PM-v1.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-FG2_PM-v1.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-FG3_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-FG3_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-FG4_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-FG4_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Fo1_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Fo1_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Fo2_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Fo2_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Fo3_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Fo3_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Fo4_PM-v2.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Fo4_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Fo5_PM-v2.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Fo5_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Fo6_PM-v2.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Fo6_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Fo7_PM-v2.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Fo7_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Fp1_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Fp1_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Fp2_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Fp2_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Ia_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Ia_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Id1_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Id1_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Id2_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Id2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Id3_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Id3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Id4_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Id4_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Id5_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Id5_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Id6_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Id6_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Id7_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Id7_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Ig1_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Ig1_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Ig2_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Ig2_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Ig3_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Ig3_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-OP1_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-OP1_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-OP2_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-OP2_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-OP3_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-OP3_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-OP4_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-OP4_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-OP5_PM-v2.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-OP5_PM-v2.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-OP6_PM-v2.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-OP6_PM-v2.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-OP7_PM-v2.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-OP7_PM-v2.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-OP8_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-OP8_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-OP9_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-OP9_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-PF_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-PF_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-PFcm_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-PFcm_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-PFm_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-PFm_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-PFop_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-PFop_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-PFt_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-PFt_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-PGa_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-PGa_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-PGp_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-PGp_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-STS1_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-STS1_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-STS2_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-STS2_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-TE-1.0_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-TE-1.0_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-TE-1.1_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-TE-1.1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-TE-1.2_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-TE-1.2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-TE-2.1_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-TE-2.1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-TE-2.2_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-TE-2.2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-TE-3_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-TE-3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-TI_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-TI_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-TeI_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-TeI_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-a29_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-a29_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-a30_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-a30_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hIP1_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hIP1_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hIP2_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hIP2_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hIP3_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hIP3_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hIP4_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hIP4_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hIP5_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hIP5_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hIP6_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hIP6_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hIP7_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hIP7_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hIP8_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hIP8_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hOc1_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hOc1_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hOc2_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hOc2_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hOc3d_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hOc3d_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hOc3v_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hOc3v_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hOc4d_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hOc4d_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hOc4la_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hOc4la_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hOc4lp_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hOc4lp_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hOc4v_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hOc4v_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hOc5_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hOc5_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hOc6_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hOc6_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hPO1_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hPO1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-i29_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-i29_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-i30_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-i30_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-p24ab_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-p24ab_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-p24c_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-p24c_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-p29_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-p29_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-p30_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-p30_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-p32_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-p32_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-s24_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-s24_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-s32_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-s32_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_CA1_PM-v11.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_CA1_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_CA2_PM-v11.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_CA2_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_CA3_PM-v11.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_CA3_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_CM_PM-v6.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_CM_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Ch-123_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Ch-123_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Ch-4_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Ch-4_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_DG_PM-v11.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_DG_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Dorsal-Dentate-Nucleus_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Dorsal-Dentate-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Entorhinal-Cortex_PM-v11.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Entorhinal-Cortex_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Fastigial-Nucleus_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Fastigial-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Frontal-II_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Frontal-II_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Frontal-I_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Frontal-I_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Frontal-to-Occipital_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Frontal-to-Occipital_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Frontal-to-Temporal_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Frontal-to-Temporal_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_HATA_PM-v11.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_HATA_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_IF_PM-v6.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_IF_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Interposed-Nucleus_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Interposed-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_LB_PM-v6.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_LB_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_MF_PM-v6.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_MF_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_SF_PM-v6.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_SF_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Subiculum_PM-v11.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Subiculum_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Temporal-to-Parietal_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Temporal-to-Parietal_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_VTM_PM-v6.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_VTM_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Ventral-Dentate-Nucleus_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Ventral-Dentate-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-1_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-1_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-25_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-25_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-2_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-2_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-33_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-33_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-3a_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-3a_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-3b_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-3b_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-44_PM-v7.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-44_PM-v7.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-45_PM-v7.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-45_PM-v7.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-4a_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-4a_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-4p_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-4p_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-5Ci_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-5Ci_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-5L_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-5L_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-5M_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-5M_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-6d1_PM-v4.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-6d1_PM-v4.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-6d2_PM-v4.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-6d2_PM-v4.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-6d3_PM-v4.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-6d3_PM-v4.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-6ma_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-6ma_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-6mp_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-6mp_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-7A_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-7A_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-7PC_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-7PC_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-7P_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-7P_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-FG1_PM-v1.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-FG1_PM-v1.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-FG2_PM-v1.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-FG2_PM-v1.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-FG3_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-FG3_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-FG4_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-FG4_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Fo1_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Fo1_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Fo2_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Fo2_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Fo3_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Fo3_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Fo4_PM-v2.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Fo4_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Fo5_PM-v2.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Fo5_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Fo6_PM-v2.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Fo6_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Fo7_PM-v2.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Fo7_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Fp1_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Fp1_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Fp2_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Fp2_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Ia_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Ia_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Id1_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Id1_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Id2_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Id2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Id3_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Id3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Id4_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Id4_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Id5_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Id5_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Id6_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Id6_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Id7_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Id7_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Ig1_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Ig1_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Ig2_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Ig2_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Ig3_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Ig3_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-OP1_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-OP1_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-OP2_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-OP2_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-OP3_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-OP3_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-OP4_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-OP4_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-OP5_PM-v2.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-OP5_PM-v2.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-OP6_PM-v2.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-OP6_PM-v2.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-OP7_PM-v2.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-OP7_PM-v2.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-OP8_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-OP8_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-OP9_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-OP9_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-PF_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-PF_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-PFcm_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-PFcm_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-PFm_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-PFm_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-PFop_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-PFop_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-PFt_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-PFt_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-PGa_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-PGa_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-PGp_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-PGp_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-STS1_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-STS1_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-STS2_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-STS2_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-TE-1.0_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-TE-1.0_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-TE-1.1_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-TE-1.1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-TE-1.2_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-TE-1.2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-TE-2.1_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-TE-2.1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-TE-2.2_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-TE-2.2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-TE-3_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-TE-3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-TI_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-TI_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-TeI_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-TeI_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-a29_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-a29_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-a30_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-a30_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hIP1_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hIP1_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hIP2_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hIP2_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hIP3_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hIP3_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hIP4_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hIP4_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hIP5_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hIP5_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hIP6_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hIP6_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hIP7_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hIP7_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hIP8_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hIP8_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hOc1_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hOc1_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hOc2_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hOc2_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hOc3d_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hOc3d_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hOc3v_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hOc3v_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hOc4d_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hOc4d_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hOc4la_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hOc4la_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hOc4lp_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hOc4lp_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hOc4v_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hOc4v_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hOc5_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hOc5_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hOc6_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hOc6_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hPO1_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hPO1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-i29_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-i29_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-i30_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-i30_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-p24ab_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-p24ab_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-p24c_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-p24c_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-p29_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-p29_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-p30_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-p30_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-p32_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-p32_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-s24_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-s24_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-s32_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-s32_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_CA1_PM-v11.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_CA1_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_CA2_PM-v11.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_CA2_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_CA3_PM-v11.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_CA3_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_CM_PM-v6.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_CM_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Ch-123_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Ch-123_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Ch-4_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Ch-4_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_DG_PM-v11.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_DG_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Dorsal-Dentate-Nucleus_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Dorsal-Dentate-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Entorhinal-Cortex_PM-v11.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Entorhinal-Cortex_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Fastigial-Nucleus_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Fastigial-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Frontal-II_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Frontal-II_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Frontal-I_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Frontal-I_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Frontal-to-Occipital_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Frontal-to-Occipital_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Frontal-to-Temporal_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Frontal-to-Temporal_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_HATA_PM-v11.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_HATA_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_IF_PM-v6.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_IF_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Interposed-Nucleus_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Interposed-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_LB_PM-v6.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_LB_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_MF_PM-v6.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_MF_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_SF_PM-v6.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_SF_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Subiculum_PM-v11.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Subiculum_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Temporal-to-Parietal_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Temporal-to-Parietal_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_VTM_PM-v6.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_VTM_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Ventral-Dentate-Nucleus_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Ventral-Dentate-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-1_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-1_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-25_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-25_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-2_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-2_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-33_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-33_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-3a_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-3a_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-3b_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-3b_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-44_PM-v7.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-44_PM-v7.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-45_PM-v7.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-45_PM-v7.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-4a_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-4a_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-4p_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-4p_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-5Ci_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-5Ci_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-5L_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-5L_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-5M_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-5M_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-6d1_PM-v4.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-6d1_PM-v4.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-6d2_PM-v4.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-6d2_PM-v4.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-6d3_PM-v4.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-6d3_PM-v4.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-6ma_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-6ma_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-6mp_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-6mp_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-7A_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-7A_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-7PC_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-7PC_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-7P_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-7P_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-FG1_PM-v1.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-FG1_PM-v1.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-FG2_PM-v1.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-FG2_PM-v1.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-FG3_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-FG3_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-FG4_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-FG4_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Fo1_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Fo1_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Fo2_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Fo2_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Fo3_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Fo3_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Fo4_PM-v2.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Fo4_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Fo5_PM-v2.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Fo5_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Fo6_PM-v2.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Fo6_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Fo7_PM-v2.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Fo7_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Fp1_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Fp1_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Fp2_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Fp2_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Ia_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Ia_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Id1_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Id1_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Id2_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Id2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Id3_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Id3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Id4_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Id4_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Id5_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Id5_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Id6_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Id6_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Id7_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Id7_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Ig1_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Ig1_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Ig2_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Ig2_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Ig3_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Ig3_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-OP1_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-OP1_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-OP2_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-OP2_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-OP3_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-OP3_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-OP4_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-OP4_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-OP5_PM-v2.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-OP5_PM-v2.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-OP6_PM-v2.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-OP6_PM-v2.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-OP7_PM-v2.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-OP7_PM-v2.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-OP8_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-OP8_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-OP9_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-OP9_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-PF_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-PF_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-PFcm_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-PFcm_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-PFm_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-PFm_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-PFop_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-PFop_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-PFt_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-PFt_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-PGa_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-PGa_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-PGp_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-PGp_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-STS1_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-STS1_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-STS2_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-STS2_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-TE-1.0_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-TE-1.0_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-TE-1.1_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-TE-1.1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-TE-1.2_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-TE-1.2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-TE-2.1_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-TE-2.1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-TE-2.2_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-TE-2.2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-TE-3_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-TE-3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-TI_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-TI_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-TeI_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-TeI_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-a29_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-a29_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-a30_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-a30_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hIP1_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hIP1_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hIP2_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hIP2_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hIP3_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hIP3_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hIP4_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hIP4_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hIP5_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hIP5_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hIP6_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hIP6_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hIP7_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hIP7_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hIP8_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hIP8_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hOc1_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hOc1_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hOc2_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hOc2_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hOc3d_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hOc3d_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hOc3v_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hOc3v_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hOc4d_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hOc4d_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hOc4la_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hOc4la_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hOc4lp_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hOc4lp_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hOc4v_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hOc4v_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hOc5_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hOc5_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hOc6_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hOc6_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hPO1_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hPO1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-i29_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-i29_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-i30_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-i30_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-p24ab_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-p24ab_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-p24c_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-p24c_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-p29_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-p29_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-p30_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-p30_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-p32_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-p32_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-s24_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-s24_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-s32_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-s32_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_CA1_PM-v11.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_CA1_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_CA2_PM-v11.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_CA2_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_CA3_PM-v11.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_CA3_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_CM_PM-v6.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_CM_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Ch-123_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Ch-123_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Ch-4_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Ch-4_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_DG_PM-v11.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_DG_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Dorsal-Dentate-Nucleus_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Dorsal-Dentate-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Entorhinal-Cortex_PM-v11.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Entorhinal-Cortex_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Fastigial-Nucleus_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Fastigial-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Frontal-II_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Frontal-II_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Frontal-I_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Frontal-I_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Frontal-to-Occipital_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Frontal-to-Occipital_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Frontal-to-Temporal_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Frontal-to-Temporal_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_HATA_PM-v11.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_HATA_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_IF_PM-v6.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_IF_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Interposed-Nucleus_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Interposed-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_LB_PM-v6.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_LB_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_MF_PM-v6.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_MF_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_SF_PM-v6.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_SF_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Subiculum_PM-v11.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Subiculum_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Temporal-to-Parietal_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Temporal-to-Parietal_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_VTM_PM-v6.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_VTM_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Ventral-Dentate-Nucleus_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Ventral-Dentate-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-1_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-1_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-25_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-25_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-2_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-2_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-33_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-33_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-3a_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-3a_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-3b_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-3b_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-44_PM-v7.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-44_PM-v7.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-45_PM-v7.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-45_PM-v7.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-4a_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-4a_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-4p_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-4p_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-5Ci_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-5Ci_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-5L_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-5L_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-5M_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-5M_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-6d1_PM-v4.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-6d1_PM-v4.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-6d2_PM-v4.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-6d2_PM-v4.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-6d3_PM-v4.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-6d3_PM-v4.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-6ma_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-6ma_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-6mp_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-6mp_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-7A_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-7A_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-7PC_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-7PC_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-7P_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-7P_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-FG1_PM-v1.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-FG1_PM-v1.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-FG2_PM-v1.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-FG2_PM-v1.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-FG3_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-FG3_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-FG4_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-FG4_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Fo1_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Fo1_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Fo2_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Fo2_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Fo3_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Fo3_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Fo4_PM-v2.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Fo4_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Fo5_PM-v2.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Fo5_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Fo6_PM-v2.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Fo6_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Fo7_PM-v2.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Fo7_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Fp1_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Fp1_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Fp2_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Fp2_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Ia_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Ia_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Id1_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Id1_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Id2_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Id2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Id3_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Id3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Id4_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Id4_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Id5_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Id5_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Id6_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Id6_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Id7_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Id7_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Ig1_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Ig1_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Ig2_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Ig2_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Ig3_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Ig3_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-OP1_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-OP1_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-OP2_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-OP2_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-OP3_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-OP3_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-OP4_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-OP4_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-OP5_PM-v2.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-OP5_PM-v2.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-OP6_PM-v2.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-OP6_PM-v2.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-OP7_PM-v2.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-OP7_PM-v2.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-OP8_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-OP8_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-OP9_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-OP9_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-PF_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-PF_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-PFcm_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-PFcm_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-PFm_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-PFm_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-PFop_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-PFop_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-PFt_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-PFt_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-PGa_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-PGa_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-PGp_PM-v9.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-PGp_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-STS1_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-STS1_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-STS2_PM-v3.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-STS2_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-TE-1.0_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-TE-1.0_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-TE-1.1_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-TE-1.1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-TE-1.2_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-TE-1.2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-TE-2.1_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-TE-2.1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-TE-2.2_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-TE-2.2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-TE-3_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-TE-3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-TI_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-TI_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-TeI_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-TeI_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-a29_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-a29_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-a30_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-a30_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hIP1_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hIP1_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hIP2_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hIP2_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hIP3_PM-v8.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hIP3_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hIP4_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hIP4_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hIP5_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hIP5_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hIP6_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hIP6_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hIP7_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hIP7_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hIP8_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hIP8_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hOc1_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hOc1_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hOc2_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hOc2_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hOc3d_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hOc3d_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hOc3v_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hOc3v_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hOc4d_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hOc4d_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hOc4la_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hOc4la_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hOc4lp_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hOc4lp_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hOc4v_PM-v3.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hOc4v_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hOc5_PM-v2.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hOc5_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hOc6_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hOc6_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hPO1_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hPO1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-i29_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-i29_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-i30_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-i30_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-p24ab_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-p24ab_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-p24c_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-p24c_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-p29_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-p29_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-p30_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-p30_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-p32_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-p32_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-s24_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-s24_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-s32_PM-v16.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-s32_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_CA1_PM-v11.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_CA1_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_CA2_PM-v11.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_CA2_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_CA3_PM-v11.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_CA3_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_CM_PM-v6.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_CM_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Ch-123_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Ch-123_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Ch-4_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Ch-4_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_DG_PM-v11.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_DG_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Dorsal-Dentate-Nucleus_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Dorsal-Dentate-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Entorhinal-Cortex_PM-v11.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Entorhinal-Cortex_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Fastigial-Nucleus_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Fastigial-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Frontal-II_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Frontal-II_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Frontal-I_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Frontal-I_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Frontal-to-Occipital_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Frontal-to-Occipital_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Frontal-to-Temporal_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Frontal-to-Temporal_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_HATA_PM-v11.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_HATA_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_IF_PM-v6.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_IF_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Interposed-Nucleus_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Interposed-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_LB_PM-v6.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_LB_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_MF_PM-v6.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_MF_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_SF_PM-v6.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_SF_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Subiculum_PM-v11.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Subiculum_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Temporal-to-Parietal_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Temporal-to-Parietal_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_VTM_PM-v6.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_VTM_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Ventral-Dentate-Nucleus_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Ventral-Dentate-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-1_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-1_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-25_PM-v18.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-25_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-2_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-2_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-33_PM-v18.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-33_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-3a_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-3a_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-3b_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-3b_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-44_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-44_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-45_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-45_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-4a_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-4a_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-4p_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-4p_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-5Ci_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-5Ci_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-5L_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-5L_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-5M_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-5M_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-6d1_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-6d1_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-6d2_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-6d2_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-6d3_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-6d3_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-6ma_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-6ma_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-6mp_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-6mp_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-7A_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-7A_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-7M_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-7M_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-7PC_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-7PC_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-7P_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-7P_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-FG1_PM-v3.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-FG1_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-FG2_PM-v3.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-FG2_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-FG3_PM-v7.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-FG3_PM-v7.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-FG4_PM-v7.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-FG4_PM-v7.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Fo1_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Fo1_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Fo2_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Fo2_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Fo3_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Fo3_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Fo4_PM-v3.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Fo4_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Fo5_PM-v3.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Fo5_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Fo6_PM-v3.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Fo6_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Fo7_PM-v3.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Fo7_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Fp1_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Fp1_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Fp2_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Fp2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Ia_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Ia_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Id1_PM-v14.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Id1_PM-v14.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Id2_PM-v8.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Id2_PM-v8.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Id3_PM-v8.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Id3_PM-v8.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Id4_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Id4_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Id5_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Id5_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Id6_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Id6_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Id7_PM-v7.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Id7_PM-v7.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Ig1_PM-v14.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Ig1_PM-v14.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Ig2_PM-v14.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Ig2_PM-v14.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Ig3_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Ig3_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-OP1_PM-v12.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-OP1_PM-v12.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-OP2_PM-v12.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-OP2_PM-v12.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-OP3_PM-v12.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-OP3_PM-v12.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-OP4_PM-v12.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-OP4_PM-v12.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-OP5_PM-v3.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-OP5_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-OP6_PM-v3.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-OP6_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-OP7_PM-v3.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-OP7_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-OP8_PM-v6.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-OP8_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-OP9_PM-v6.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-OP9_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-PF_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-PF_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-PFcm_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-PFcm_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-PFm_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-PFm_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-PFop_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-PFop_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-PFt_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-PFt_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-PGa_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-PGa_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-PGp_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-PGp_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-STS1_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-STS1_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-STS2_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-STS2_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-TE-1.0_PM-v6.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-TE-1.0_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-TE-1.1_PM-v6.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-TE-1.1_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-TE-1.2_PM-v6.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-TE-1.2_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-TE-2.1_PM-v6.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-TE-2.1_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-TE-2.2_PM-v6.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-TE-2.2_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-TE-3_PM-v6.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-TE-3_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-TI_PM-v6.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-TI_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-TeI_PM-v6.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-TeI_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hIP1_PM-v7.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hIP1_PM-v7.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hIP2_PM-v7.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hIP2_PM-v7.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hIP3_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hIP3_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hIP4_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hIP4_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hIP5_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hIP5_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hIP6_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hIP6_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hIP7_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hIP7_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hIP8_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hIP8_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hOc1_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hOc1_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hOc2_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hOc2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hOc3d_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hOc3d_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hOc3v_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hOc3v_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hOc4d_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hOc4d_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hOc4la_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hOc4la_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hOc4lp_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hOc4lp_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hOc4v_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hOc4v_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hOc5_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hOc5_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hOc6_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hOc6_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hPO1_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hPO1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-p24ab_PM-v18.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-p24ab_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-p24c_PM-v18.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-p24c_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-p32_PM-v18.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-p32_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-s24_PM-v18.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-s24_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-s32_PM-v18.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-s32_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_CA1_PM-v13.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_CA1_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_CA2_PM-v13.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_CA2_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_CA3_PM-v13.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_CA3_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_CM_PM-v8.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_CM_PM-v8.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Ch-123_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Ch-123_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Ch-4_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Ch-4_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_DG_PM-v13.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_DG_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Dorsal-Dentate-Nucleus_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Dorsal-Dentate-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Entorhinal-Cortex_PM-v13.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Entorhinal-Cortex_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Fastigial-Nucleus_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Fastigial-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Frontal-II_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Frontal-II_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Frontal-I_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Frontal-I_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Frontal-to-Occipital_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Frontal-to-Occipital_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Frontal-to-Temporal_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Frontal-to-Temporal_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_HATA_PM-v13.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_HATA_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_HC-Transsubiculum_PM-v13.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_HC-Transsubiculum_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_IF_PM-v8.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_IF_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Interposed-Nucleus_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Interposed-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_LB_PM-v8.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_LB_PM-v8.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_MF_PM-v8.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_MF_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_SF_PM-v8.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_SF_PM-v8.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Subiculum.PaS_PM-v13.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Subiculum.PaS_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Subiculum.PreS_PM-v13.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Subiculum.PreS_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Subiculum.ProS_PM-v13.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Subiculum.ProS_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Subiculum.Sub_PM-v13.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Subiculum.Sub_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Temporal-to-Parietal_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Temporal-to-Parietal_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_VTM_PM-v8.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_VTM_PM-v8.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Ventral-Dentate-Nucleus_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Ventral-Dentate-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-1_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-1_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-25_PM-v18.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-25_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-2_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-2_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-33_PM-v18.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-33_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-3a_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-3a_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-3b_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-3b_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-44_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-44_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-45_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-45_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-4a_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-4a_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-4p_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-4p_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-5Ci_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-5Ci_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-5L_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-5L_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-5M_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-5M_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-6d1_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-6d1_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-6d2_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-6d2_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-6d3_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-6d3_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-6ma_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-6ma_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-6mp_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-6mp_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-7A_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-7A_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-7M_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-7M_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-7PC_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-7PC_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-7P_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-7P_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-FG1_PM-v3.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-FG1_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-FG2_PM-v3.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-FG2_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-FG3_PM-v7.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-FG3_PM-v7.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-FG4_PM-v7.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-FG4_PM-v7.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Fo1_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Fo1_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Fo2_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Fo2_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Fo3_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Fo3_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Fo4_PM-v3.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Fo4_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Fo5_PM-v3.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Fo5_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Fo6_PM-v3.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Fo6_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Fo7_PM-v3.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Fo7_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Fp1_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Fp1_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Fp2_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Fp2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Ia_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Ia_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Id1_PM-v14.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Id1_PM-v14.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Id2_PM-v8.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Id2_PM-v8.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Id3_PM-v8.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Id3_PM-v8.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Id4_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Id4_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Id5_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Id5_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Id6_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Id6_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Id7_PM-v7.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Id7_PM-v7.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Ig1_PM-v14.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Ig1_PM-v14.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Ig2_PM-v14.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Ig2_PM-v14.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Ig3_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Ig3_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-OP1_PM-v12.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-OP1_PM-v12.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-OP2_PM-v12.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-OP2_PM-v12.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-OP3_PM-v12.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-OP3_PM-v12.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-OP4_PM-v12.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-OP4_PM-v12.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-OP5_PM-v3.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-OP5_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-OP6_PM-v3.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-OP6_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-OP7_PM-v3.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-OP7_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-OP8_PM-v6.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-OP8_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-OP9_PM-v6.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-OP9_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-PF_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-PF_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-PFcm_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-PFcm_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-PFm_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-PFm_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-PFop_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-PFop_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-PFt_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-PFt_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-PGa_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-PGa_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-PGp_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-PGp_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-STS1_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-STS1_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-STS2_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-STS2_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-TE-1.0_PM-v6.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-TE-1.0_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-TE-1.1_PM-v6.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-TE-1.1_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-TE-1.2_PM-v6.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-TE-1.2_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-TE-2.1_PM-v6.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-TE-2.1_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-TE-2.2_PM-v6.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-TE-2.2_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-TE-3_PM-v6.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-TE-3_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-TI_PM-v6.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-TI_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-TeI_PM-v6.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-TeI_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hIP1_PM-v7.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hIP1_PM-v7.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hIP2_PM-v7.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hIP2_PM-v7.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hIP3_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hIP3_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hIP4_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hIP4_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hIP5_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hIP5_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hIP6_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hIP6_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hIP7_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hIP7_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hIP8_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hIP8_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hOc1_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hOc1_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hOc2_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hOc2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hOc3d_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hOc3d_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hOc3v_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hOc3v_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hOc4d_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hOc4d_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hOc4la_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hOc4la_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hOc4lp_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hOc4lp_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hOc4v_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hOc4v_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hOc5_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hOc5_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hOc6_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hOc6_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hPO1_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hPO1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-p24ab_PM-v18.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-p24ab_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-p24c_PM-v18.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-p24c_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-p32_PM-v18.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-p32_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-s24_PM-v18.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-s24_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-s32_PM-v18.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-s32_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_CA1_PM-v13.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_CA1_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_CA2_PM-v13.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_CA2_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_CA3_PM-v13.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_CA3_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_CM_PM-v8.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_CM_PM-v8.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Ch-123_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Ch-123_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Ch-4_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Ch-4_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_DG_PM-v13.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_DG_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Dorsal-Dentate-Nucleus_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Dorsal-Dentate-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Entorhinal-Cortex_PM-v13.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Entorhinal-Cortex_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Fastigial-Nucleus_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Fastigial-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Frontal-II_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Frontal-II_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Frontal-I_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Frontal-I_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Frontal-to-Occipital_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Frontal-to-Occipital_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Frontal-to-Temporal_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Frontal-to-Temporal_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_HATA_PM-v13.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_HATA_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_HC-Transsubiculum_PM-v13.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_HC-Transsubiculum_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_IF_PM-v8.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_IF_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Interposed-Nucleus_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Interposed-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_LB_PM-v8.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_LB_PM-v8.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_MF_PM-v8.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_MF_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_SF_PM-v8.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_SF_PM-v8.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Subiculum.PaS_PM-v13.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Subiculum.PaS_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Subiculum.PreS_PM-v13.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Subiculum.PreS_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Subiculum.ProS_PM-v13.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Subiculum.ProS_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Subiculum.Sub_PM-v13.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Subiculum.Sub_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Temporal-to-Parietal_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Temporal-to-Parietal_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_VTM_PM-v8.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_VTM_PM-v8.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Ventral-Dentate-Nucleus_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Ventral-Dentate-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-1_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-1_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-25_PM-v18.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-25_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-2_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-2_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-33_PM-v18.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-33_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-3a_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-3a_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-3b_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-3b_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-44_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-44_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-45_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-45_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-4a_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-4a_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-4p_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-4p_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-5Ci_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-5Ci_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-5L_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-5L_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-5M_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-5M_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-6d1_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-6d1_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-6d2_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-6d2_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-6d3_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-6d3_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-6ma_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-6ma_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-6mp_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-6mp_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-7A_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-7A_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-7M_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-7M_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-7PC_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-7PC_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-7P_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-7P_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-FG1_PM-v3.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-FG1_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-FG2_PM-v3.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-FG2_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-FG3_PM-v7.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-FG3_PM-v7.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-FG4_PM-v7.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-FG4_PM-v7.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Fo1_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Fo1_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Fo2_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Fo2_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Fo3_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Fo3_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Fo4_PM-v3.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Fo4_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Fo5_PM-v3.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Fo5_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Fo6_PM-v3.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Fo6_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Fo7_PM-v3.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Fo7_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Fp1_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Fp1_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Fp2_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Fp2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Ia_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Ia_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Id1_PM-v14.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Id1_PM-v14.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Id2_PM-v8.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Id2_PM-v8.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Id3_PM-v8.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Id3_PM-v8.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Id4_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Id4_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Id5_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Id5_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Id6_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Id6_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Id7_PM-v7.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Id7_PM-v7.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Ig1_PM-v14.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Ig1_PM-v14.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Ig2_PM-v14.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Ig2_PM-v14.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Ig3_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Ig3_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-OP1_PM-v12.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-OP1_PM-v12.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-OP2_PM-v12.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-OP2_PM-v12.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-OP3_PM-v12.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-OP3_PM-v12.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-OP4_PM-v12.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-OP4_PM-v12.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-OP5_PM-v3.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-OP5_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-OP6_PM-v3.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-OP6_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-OP7_PM-v3.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-OP7_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-OP8_PM-v6.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-OP8_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-OP9_PM-v6.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-OP9_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-PF_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-PF_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-PFcm_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-PFcm_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-PFm_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-PFm_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-PFop_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-PFop_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-PFt_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-PFt_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-PGa_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-PGa_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-PGp_PM-v11.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-PGp_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-STS1_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-STS1_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-STS2_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-STS2_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-TE-1.0_PM-v6.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-TE-1.0_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-TE-1.1_PM-v6.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-TE-1.1_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-TE-1.2_PM-v6.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-TE-1.2_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-TE-2.1_PM-v6.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-TE-2.1_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-TE-2.2_PM-v6.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-TE-2.2_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-TE-3_PM-v6.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-TE-3_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-TI_PM-v6.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-TI_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-TeI_PM-v6.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-TeI_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hIP1_PM-v7.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hIP1_PM-v7.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hIP2_PM-v7.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hIP2_PM-v7.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hIP3_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hIP3_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hIP4_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hIP4_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hIP5_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hIP5_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hIP6_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hIP6_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hIP7_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hIP7_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hIP8_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hIP8_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hOc1_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hOc1_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hOc2_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hOc2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hOc3d_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hOc3d_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hOc3v_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hOc3v_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hOc4d_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hOc4d_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hOc4la_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hOc4la_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hOc4lp_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hOc4lp_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hOc4v_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hOc4v_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hOc5_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hOc5_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hOc6_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hOc6_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hPO1_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hPO1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-p24ab_PM-v18.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-p24ab_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-p24c_PM-v18.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-p24c_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-p32_PM-v18.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-p32_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-s24_PM-v18.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-s24_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-s32_PM-v18.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-s32_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_CA1_PM-v13.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_CA1_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_CA2_PM-v13.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_CA2_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_CA3_PM-v13.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_CA3_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_CM_PM-v8.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_CM_PM-v8.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Ch-123_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Ch-123_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Ch-4_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Ch-4_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_DG_PM-v13.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_DG_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Dorsal-Dentate-Nucleus_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Dorsal-Dentate-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Entorhinal-Cortex_PM-v13.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Entorhinal-Cortex_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Fastigial-Nucleus_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Fastigial-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Frontal-II_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Frontal-II_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Frontal-I_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Frontal-I_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Frontal-to-Occipital_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Frontal-to-Occipital_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Frontal-to-Temporal_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Frontal-to-Temporal_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_HATA_PM-v13.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_HATA_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_HC-Transsubiculum_PM-v13.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_HC-Transsubiculum_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_IF_PM-v8.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_IF_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Interposed-Nucleus_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Interposed-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_LB_PM-v8.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_LB_PM-v8.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_MF_PM-v8.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_MF_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_SF_PM-v8.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_SF_PM-v8.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Subiculum.PaS_PM-v13.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Subiculum.PaS_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Subiculum.PreS_PM-v13.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Subiculum.PreS_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Subiculum.ProS_PM-v13.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Subiculum.ProS_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Subiculum.Sub_PM-v13.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Subiculum.Sub_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Temporal-to-Parietal_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Temporal-to-Parietal_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_VTM_PM-v8.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_VTM_PM-v8.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Ventral-Dentate-Nucleus_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Ventral-Dentate-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-6d1_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-6d1_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-6d2_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-6d2_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-6d3_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-6d3_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-6ma_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-6ma_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-MFG1_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-MFG1_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-MFG2_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-MFG2_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-SFS1_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-SFS1_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-SFS2_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-SFS2_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-STS1_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-STS1_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-STS2_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-STS2_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-TE-1.0_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-TE-1.0_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-TE-1.1_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-TE-1.1_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-TE-1.2_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-TE-1.2_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-TE-3_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-TE-3_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hIP4_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hIP4_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hIP5_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hIP5_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hIP6_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hIP6_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hIP7_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hIP7_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hIP8_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hIP8_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hOc1_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hOc1_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hOc2_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hOc2_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hOc3v_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hOc3v_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hOc5_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hOc5_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hOc6_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hOc6_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hPO1_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hPO1_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_CGL.lam1_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_CGL.lam1_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_CGL.lam2_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_CGL.lam2_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_CGL.lam3_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_CGL.lam3_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_CGL.lam4_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_CGL.lam4_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_CGL.lam5_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_CGL.lam5_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_CGL.lam6_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_CGL.lam6_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_CGM.CGMd_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_CGM.CGMd_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_CGM.CGMm_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_CGM.CGMm_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_CGM.CGMv_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_CGM.CGMv_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Entorhinal-Cortex_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Entorhinal-Cortex_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-1_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-1_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-25_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-25_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-2_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-33_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-33_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-3a_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-3a_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-3b_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-3b_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-44_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-44_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-45_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-45_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-4a_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-4a_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-4p_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-4p_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-5Ci_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-5Ci_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-5L_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-5L_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-5M_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-5M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-6d1_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-6d1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-6d2_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-6d2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-6d3_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-6d3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-6ma_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-6ma_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-6mp_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-6mp_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-7A_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-7A_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-7M_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-7M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-7PC_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-7PC_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-7P_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-7P_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-8d1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-8d1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-8d2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-8d2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-8v1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-8v1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-8v2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-8v2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-CoS1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-CoS1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-FG1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-FG1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-FG2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-FG2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-FG3_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-FG3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-FG4_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-FG4_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Fo1_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Fo1_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Fo2_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Fo2_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Fo3_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Fo3_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Fo4_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Fo4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Fo5_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Fo5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Fo6_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Fo6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Fo7_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Fo7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Fp1_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Fp1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Fp2_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Fp2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-IFJ1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-IFJ1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-IFJ2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-IFJ2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-IFS1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-IFS1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-IFS2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-IFS2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-IFS3_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-IFS3_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-IFS4_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-IFS4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Ia1_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Ia1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Ia2_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Ia2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Ia3_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Ia3_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Id10_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Id10_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Id1_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Id1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Id2_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Id2_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Id3_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Id3_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Id4_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Id4_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Id5_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Id5_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Id6_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Id6_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Id7_PM-v8.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Id7_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Id8_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Id8_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Id9_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Id9_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Ig1_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Ig1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Ig2_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Ig2_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Ig3_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Ig3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-OP1_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-OP1_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-OP2_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-OP2_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-OP3_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-OP3_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-OP4_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-OP4_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-OP5_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-OP5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-OP6_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-OP6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-OP7_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-OP7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-OP8_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-OP8_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-OP9_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-OP9_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-PF_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-PF_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-PFcm_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-PFcm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-PFm_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-PFm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-PFop_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-PFop_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-PFt_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-PFt_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-PGa_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-PGa_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-PGp_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-PGp_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Ph1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Ph1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Ph2_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Ph2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Ph3_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Ph3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-STS1_PM-v5.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-STS1_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-STS2_PM-v5.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-STS2_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-TE-1.0_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-TE-1.0_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-TE-1.1_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-TE-1.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-TE-1.2_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-TE-1.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-TE-2.1_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-TE-2.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-TE-2.2_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-TE-2.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-TE-3_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-TE-3_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-TI_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-TI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-TPJ_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-TPJ_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-TeI_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-TeI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hIP1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hIP1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hIP2_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hIP2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hIP3_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hIP3_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hIP4_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hIP4_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hIP5_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hIP5_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hIP6_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hIP6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hIP7_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hIP7_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hIP8_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hIP8_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hOc1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hOc1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hOc2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hOc2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hOc3d_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hOc3d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hOc3v_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hOc3v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hOc4d_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hOc4d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hOc4la_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hOc4la_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hOc4lp_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hOc4lp_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hOc4v_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hOc4v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hOc5_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hOc5_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hOc6_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hOc6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hPO1_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hPO1_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-p24ab_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-p24ab_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-p24c_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-p24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-p32_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-p32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-s24_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-s24_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-s32_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-s32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_BST_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_BST_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_CA1_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_CA1_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_CA2_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_CA2_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_CA3_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_CA3_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_CGL_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_CGL_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_CGM_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_CGM_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_CM_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_CM_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Ch-123_PM-v4.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Ch-123_PM-v4.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Ch-4_PM-v4.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Ch-4_PM-v4.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_DG_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_DG_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Dorsal-Dentate-Nucleus_PM-v6.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Dorsal-Dentate-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Entorhinal-Cortex_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Entorhinal-Cortex_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Fastigial-Nucleus_PM-v6.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Fastigial-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Frontal-II_PM-v11.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Frontal-II_PM-v11.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Frontal-I_PM-v11.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Frontal-I_PM-v11.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Frontal-to-Occipital_PM-v11.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Frontal-to-Occipital_PM-v11.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Frontal-to-Temporal-II_PM-v11.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Frontal-to-Temporal-II_PM-v11.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Frontal-to-Temporal-I_PM-v11.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Frontal-to-Temporal-I_PM-v11.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_HATA_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_HATA_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_HC-Transsubiculum_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_HC-Transsubiculum_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_IF_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_IF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Interposed-Nucleus_PM-v6.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Interposed-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_LB_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_LB_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_MF_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_MF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_SF_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_SF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Subiculum.PaS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Subiculum.PaS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Subiculum.PreS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Subiculum.PreS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Subiculum.ProS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Subiculum.ProS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Subiculum.Sub_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Subiculum.Sub_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Temporal-to-Parietal_PM-v11.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Temporal-to-Parietal_PM-v11.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_VTM_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_VTM_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Ventral-Dentate-Nucleus_PM-v6.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Ventral-Dentate-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-1_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-1_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-25_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-25_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-2_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-33_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-33_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-3a_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-3a_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-3b_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-3b_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-44_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-44_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-45_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-45_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-4a_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-4a_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-4p_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-4p_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-5Ci_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-5Ci_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-5L_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-5L_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-5M_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-5M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-6d1_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-6d1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-6d2_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-6d2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-6d3_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-6d3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-6ma_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-6ma_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-6mp_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-6mp_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-7A_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-7A_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-7M_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-7M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-7PC_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-7PC_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-7P_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-7P_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-8d1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-8d1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-8d2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-8d2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-8v1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-8v1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-8v2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-8v2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-CoS1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-CoS1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-FG1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-FG1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-FG2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-FG2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-FG3_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-FG3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-FG4_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-FG4_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Fo1_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Fo1_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Fo2_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Fo2_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Fo3_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Fo3_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Fo4_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Fo4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Fo5_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Fo5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Fo6_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Fo6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Fo7_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Fo7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Fp1_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Fp1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Fp2_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Fp2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-IFJ1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-IFJ1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-IFJ2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-IFJ2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-IFS1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-IFS1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-IFS2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-IFS2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-IFS3_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-IFS3_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-IFS4_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-IFS4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Ia1_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Ia1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Ia2_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Ia2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Ia3_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Ia3_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Id10_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Id10_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Id1_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Id1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Id2_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Id2_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Id3_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Id3_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Id4_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Id4_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Id5_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Id5_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Id6_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Id6_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Id7_PM-v8.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Id7_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Id8_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Id8_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Id9_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Id9_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Ig1_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Ig1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Ig2_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Ig2_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Ig3_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Ig3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-OP1_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-OP1_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-OP2_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-OP2_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-OP3_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-OP3_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-OP4_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-OP4_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-OP5_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-OP5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-OP6_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-OP6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-OP7_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-OP7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-OP8_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-OP8_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-OP9_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-OP9_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-PF_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-PF_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-PFcm_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-PFcm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-PFm_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-PFm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-PFop_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-PFop_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-PFt_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-PFt_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-PGa_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-PGa_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-PGp_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-PGp_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Ph1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Ph1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Ph2_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Ph2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Ph3_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Ph3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-STS1_PM-v5.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-STS1_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-STS2_PM-v5.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-STS2_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-TE-1.0_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-TE-1.0_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-TE-1.1_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-TE-1.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-TE-1.2_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-TE-1.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-TE-2.1_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-TE-2.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-TE-2.2_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-TE-2.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-TE-3_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-TE-3_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-TI_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-TI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-TPJ_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-TPJ_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-TeI_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-TeI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hIP1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hIP1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hIP2_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hIP2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hIP3_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hIP3_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hIP4_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hIP4_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hIP5_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hIP5_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hIP6_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hIP6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hIP7_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hIP7_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hIP8_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hIP8_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hOc1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hOc1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hOc2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hOc2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hOc3d_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hOc3d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hOc3v_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hOc3v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hOc4d_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hOc4d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hOc4la_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hOc4la_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hOc4lp_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hOc4lp_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hOc4v_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hOc4v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hOc5_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hOc5_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hOc6_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hOc6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hPO1_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hPO1_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-p24ab_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-p24ab_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-p24c_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-p24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-p32_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-p32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-s24_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-s24_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-s32_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-s32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_BST_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_BST_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_CA1_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_CA1_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_CA2_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_CA2_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_CA3_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_CA3_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_CGL_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_CGL_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_CGM_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_CGM_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_CM_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_CM_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Ch-123_PM-v4.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Ch-123_PM-v4.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Ch-4_PM-v4.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Ch-4_PM-v4.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_DG_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_DG_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Dorsal-Dentate-Nucleus_PM-v6.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Dorsal-Dentate-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Entorhinal-Cortex_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Entorhinal-Cortex_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Fastigial-Nucleus_PM-v6.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Fastigial-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Frontal-II_PM-v11.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Frontal-II_PM-v11.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Frontal-I_PM-v11.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Frontal-I_PM-v11.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Frontal-to-Occipital_PM-v11.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Frontal-to-Occipital_PM-v11.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Frontal-to-Temporal-II_PM-v11.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Frontal-to-Temporal-II_PM-v11.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Frontal-to-Temporal-I_PM-v11.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Frontal-to-Temporal-I_PM-v11.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_HATA_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_HATA_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_HC-Transsubiculum_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_HC-Transsubiculum_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_IF_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_IF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Interposed-Nucleus_PM-v6.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Interposed-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_LB_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_LB_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_MF_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_MF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_SF_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_SF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Subiculum.PaS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Subiculum.PaS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Subiculum.PreS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Subiculum.PreS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Subiculum.ProS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Subiculum.ProS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Subiculum.Sub_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Subiculum.Sub_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Temporal-to-Parietal_PM-v11.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Temporal-to-Parietal_PM-v11.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_VTM_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_VTM_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Ventral-Dentate-Nucleus_PM-v6.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Ventral-Dentate-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-1_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-1_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-25_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-25_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-2_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-33_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-33_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-3a_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-3a_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-3b_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-3b_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-44_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-44_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-45_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-45_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-4a_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-4a_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-4p_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-4p_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-5Ci_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-5Ci_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-5L_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-5L_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-5M_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-5M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-6d1_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-6d1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-6d2_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-6d2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-6d3_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-6d3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-6ma_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-6ma_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-6mp_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-6mp_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-7A_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-7A_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-7M_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-7M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-7PC_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-7PC_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-7P_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-7P_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-8d1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-8d1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-8d2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-8d2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-8v1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-8v1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-8v2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-8v2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-CoS1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-CoS1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-FG1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-FG1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-FG2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-FG2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-FG3_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-FG3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-FG4_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-FG4_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Fo1_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Fo1_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Fo2_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Fo2_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Fo3_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Fo3_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Fo4_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Fo4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Fo5_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Fo5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Fo6_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Fo6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Fo7_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Fo7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Fp1_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Fp1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Fp2_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Fp2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-IFJ1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-IFJ1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-IFJ2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-IFJ2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-IFS1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-IFS1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-IFS2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-IFS2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-IFS3_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-IFS3_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-IFS4_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-IFS4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Ia1_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Ia1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Ia2_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Ia2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Ia3_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Ia3_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Id10_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Id10_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Id1_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Id1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Id2_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Id2_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Id3_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Id3_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Id4_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Id4_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Id5_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Id5_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Id6_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Id6_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Id7_PM-v8.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Id7_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Id8_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Id8_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Id9_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Id9_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Ig1_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Ig1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Ig2_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Ig2_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Ig3_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Ig3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-OP1_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-OP1_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-OP2_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-OP2_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-OP3_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-OP3_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-OP4_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-OP4_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-OP5_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-OP5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-OP6_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-OP6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-OP7_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-OP7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-OP8_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-OP8_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-OP9_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-OP9_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-PF_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-PF_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-PFcm_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-PFcm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-PFm_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-PFm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-PFop_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-PFop_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-PFt_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-PFt_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-PGa_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-PGa_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-PGp_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-PGp_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Ph1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Ph1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Ph2_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Ph2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Ph3_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Ph3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-STS1_PM-v5.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-STS1_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-STS2_PM-v5.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-STS2_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-TE-1.0_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-TE-1.0_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-TE-1.1_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-TE-1.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-TE-1.2_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-TE-1.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-TE-2.1_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-TE-2.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-TE-2.2_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-TE-2.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-TE-3_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-TE-3_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-TI_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-TI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-TPJ_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-TPJ_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-TeI_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-TeI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hIP1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hIP1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hIP2_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hIP2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hIP3_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hIP3_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hIP4_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hIP4_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hIP5_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hIP5_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hIP6_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hIP6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hIP7_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hIP7_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hIP8_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hIP8_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hOc1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hOc1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hOc2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hOc2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hOc3d_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hOc3d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hOc3v_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hOc3v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hOc4d_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hOc4d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hOc4la_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hOc4la_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hOc4lp_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hOc4lp_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hOc4v_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hOc4v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hOc5_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hOc5_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hOc6_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hOc6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hPO1_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hPO1_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-p24ab_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-p24ab_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-p24c_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-p24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-p32_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-p32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-s24_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-s24_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-s32_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-s32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_CA1_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_CA1_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_CA2_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_CA2_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_CA3_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_CA3_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_CGL_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_CGL_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_CGM_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_CGM_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_DG_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_DG_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Entorhinal-Cortex_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Entorhinal-Cortex_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Frontal-II_PM-v11.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Frontal-II_PM-v11.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Frontal-I_PM-v11.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Frontal-I_PM-v11.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Frontal-to-Occipital_PM-v11.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Frontal-to-Occipital_PM-v11.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Frontal-to-Temporal-II_PM-v11.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Frontal-to-Temporal-II_PM-v11.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Frontal-to-Temporal-I_PM-v11.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Frontal-to-Temporal-I_PM-v11.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_HATA_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_HATA_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_HC-Transsubiculum_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_HC-Transsubiculum_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Subiculum.PaS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Subiculum.PaS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Subiculum.PreS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Subiculum.PreS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Subiculum.ProS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Subiculum.ProS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Subiculum.Sub_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Subiculum.Sub_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Temporal-to-Parietal_PM-v11.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Temporal-to-Parietal_PM-v11.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-6d1_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-6d1_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-6d2_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-6d2_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-6d3_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-6d3_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-6ma_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-6ma_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-MFG1_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-MFG1_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-MFG2_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-MFG2_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-SFS1_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-SFS1_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-SFS2_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-SFS2_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-STS1_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-STS1_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-STS2_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-STS2_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-TE-1.0_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-TE-1.0_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-TE-1.1_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-TE-1.1_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-TE-1.2_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-TE-1.2_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-TE-3_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-TE-3_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hIP4_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hIP4_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hIP5_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hIP5_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hIP6_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hIP6_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hIP7_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hIP7_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hIP8_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hIP8_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hOc1_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hOc1_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hOc2_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hOc2_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hOc3v_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hOc3v_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hOc5_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hOc5_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hOc6_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hOc6_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hPO1_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hPO1_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_CGL.lam1_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_CGL.lam1_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_CGL.lam2_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_CGL.lam2_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_CGL.lam3_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_CGL.lam3_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_CGL.lam4_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_CGL.lam4_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_CGL.lam5_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_CGL.lam5_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_CGL.lam6_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_CGL.lam6_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_CGM.CGMd_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_CGM.CGMd_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_CGM.CGMm_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_CGM.CGMm_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_CGM.CGMv_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_CGM.CGMv_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Entorhinal-Cortex_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Entorhinal-Cortex_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_AcbL_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_AcbL_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_AcbM_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_AcbM_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-1_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-1_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-25.25a_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-25.25a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-25.25p_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-25.25p_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-25_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-25_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-2_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-33_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-33_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-3a_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-3a_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-3b_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-3b_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-44_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-44_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-45_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-45_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-4a_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-4a_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-4p_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-4p_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-5Ci_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-5Ci_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-5L_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-5L_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-5M_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-5M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-6d1_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-6d1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-6d2_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-6d2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-6d3_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-6d3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-6ma_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-6ma_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-6mp_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-6mp_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-7A_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-7A_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-7M_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-7M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-7PC_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-7PC_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-7P_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-7P_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-8d1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-8d1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-8d2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-8d2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-8v1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-8v1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-8v2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-8v2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-CoS1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-CoS1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-FG1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-FG1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-FG2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-FG2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-FG3_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-FG3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-FG4_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-FG4_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Fo1_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Fo1_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Fo2_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Fo2_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Fo3_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Fo3_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Fo4_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Fo4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Fo5_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Fo5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Fo6_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Fo6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Fo7_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Fo7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Fp1_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Fp1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Fp2_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Fp2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-IFJ1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-IFJ1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-IFJ2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-IFJ2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-IFS1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-IFS1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-IFS2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-IFS2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-IFS3_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-IFS3_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-IFS4_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-IFS4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Ia1_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Ia1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Ia2_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Ia2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Ia3_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Ia3_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Id10_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Id10_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Id1_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Id1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Id2_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Id2_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Id3_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Id3_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Id4_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Id4_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Id5_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Id5_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Id6_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Id6_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Id7_PM-v8.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Id7_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Id8_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Id8_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Id9_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Id9_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Ig1_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Ig1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Ig2_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Ig2_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Ig3_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Ig3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-MFG1_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-MFG1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-MFG2_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-MFG2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-OP1_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-OP1_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-OP2_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-OP2_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-OP3_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-OP3_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-OP4_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-OP4_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-OP5_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-OP5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-OP6_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-OP6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-OP7_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-OP7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-OP8_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-OP8_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-OP9_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-OP9_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-PF_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-PF_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-PFcm_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-PFcm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-PFm_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-PFm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-PFop_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-PFop_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-PFt_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-PFt_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-PGa_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-PGa_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-PGp_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-PGp_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Ph1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Ph1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Ph2_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Ph2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Ph3_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Ph3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-SFS1_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-SFS1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-SFS2_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-SFS2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-STS1_PM-v5.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-STS1_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-STS2_PM-v5.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-STS2_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-TE-1.0_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-TE-1.0_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-TE-1.1_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-TE-1.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-TE-1.2_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-TE-1.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-TE-2.1_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-TE-2.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-TE-2.2_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-TE-2.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-TE-3_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-TE-3_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-TI_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-TI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-TPJ_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-TPJ_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-TeI_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-TeI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hIP1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hIP1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hIP2_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hIP2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hIP3_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hIP3_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hIP4_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hIP4_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hIP5_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hIP5_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hIP6_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hIP6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hIP7_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hIP7_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hIP8_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hIP8_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hOc1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hOc1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hOc2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hOc2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hOc3d_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hOc3d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hOc3v_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hOc3v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hOc4d_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hOc4d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hOc4la_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hOc4la_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hOc4lp_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hOc4lp_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hOc4v_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hOc4v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hOc5_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hOc5_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hOc6_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hOc6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hPO1_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hPO1_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-p24ab.p24a_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-p24ab.p24a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-p24ab.p24b_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-p24ab.p24b_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-p24ab_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-p24ab_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-p24c.pd24cd_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-p24c.pd24cd_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-p24c.pd24cv_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-p24c.pd24cv_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-p24c.pv24c_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-p24c.pv24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-p24c_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-p24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-p32_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-p32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-s24.s24a_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-s24.s24a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-s24.s24b_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-s24.s24b_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-s24_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-s24_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-s32_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-s32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_BST_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_BST_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_CA1_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_CA1_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_CA2_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_CA2_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_CA3_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_CA3_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_CGL_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_CGL_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_CGM_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_CGM_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_CM.AAA_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_CM.AAA_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_CM.Ce_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_CM.Ce_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_CM.Me_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_CM.Me_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_CM_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_CM_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Ch-123_PM-v4.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Ch-123_PM-v4.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Ch-4_PM-v4.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Ch-4_PM-v4.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_DG_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_DG_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Dorsal-Dentate-Nucleus_PM-v6.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Dorsal-Dentate-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Entorhinal-Cortex_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Entorhinal-Cortex_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Fastigial-Nucleus_PM-v6.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Fastigial-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Frontal-II_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Frontal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Frontal-I_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Frontal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Frontal-to-Occipital_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Frontal-to-Occipital_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Frontal-to-Temporal-II_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Frontal-to-Temporal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Frontal-to-Temporal-I_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Frontal-to-Temporal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_FuCd_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_FuCd_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_FuP_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_FuP_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_HATA_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_HATA_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_HC-Transsubiculum_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_HC-Transsubiculum_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_IF.ice_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_IF.ice_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_IF.iol_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_IF.iol_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_IF.ld_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_IF.ld_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_IF_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_IF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Interposed-Nucleus_PM-v6.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Interposed-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_LB.Bl_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_LB.Bl_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_LB.Bm_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_LB.Bm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_LB.La_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_LB.La_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_LB.Pl_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_LB.Pl_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_LB_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_LB_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_MF.icm_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_MF.icm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_MF.lm_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_MF.lm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_MF_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_MF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_SF.AHi_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_SF.AHi_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_SF.APir_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_SF.APir_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_SF.VCo_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_SF.VCo_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_SF_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_SF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_STN_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_STN_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Subiculum.PaS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Subiculum.PaS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Subiculum.PreS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Subiculum.PreS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Subiculum.ProS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Subiculum.ProS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Subiculum.Sub_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Subiculum.Sub_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Temporal-to-Parietal_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Temporal-to-Parietal_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Terminal-islands_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Terminal-islands_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Tuberculum_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Tuberculum_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_VP_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_VP_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_VTM_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_VTM_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Ventral-Dentate-Nucleus_PM-v6.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Ventral-Dentate-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_AcbL_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_AcbL_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_AcbM_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_AcbM_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-1_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-1_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-25.25a_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-25.25a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-25.25p_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-25.25p_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-25_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-25_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-2_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-33_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-33_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-3a_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-3a_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-3b_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-3b_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-44_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-44_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-45_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-45_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-4a_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-4a_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-4p_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-4p_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-5Ci_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-5Ci_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-5L_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-5L_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-5M_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-5M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-6d1_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-6d1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-6d2_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-6d2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-6d3_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-6d3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-6ma_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-6ma_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-6mp_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-6mp_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-7A_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-7A_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-7M_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-7M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-7PC_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-7PC_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-7P_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-7P_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-8d1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-8d1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-8d2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-8d2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-8v1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-8v1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-8v2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-8v2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-CoS1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-CoS1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-FG1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-FG1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-FG2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-FG2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-FG3_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-FG3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-FG4_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-FG4_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Fo1_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Fo1_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Fo2_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Fo2_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Fo3_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Fo3_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Fo4_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Fo4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Fo5_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Fo5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Fo6_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Fo6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Fo7_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Fo7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Fp1_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Fp1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Fp2_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Fp2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-IFJ1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-IFJ1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-IFJ2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-IFJ2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-IFS1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-IFS1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-IFS2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-IFS2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-IFS3_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-IFS3_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-IFS4_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-IFS4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Ia1_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Ia1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Ia2_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Ia2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Ia3_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Ia3_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Id10_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Id10_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Id1_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Id1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Id2_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Id2_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Id3_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Id3_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Id4_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Id4_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Id5_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Id5_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Id6_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Id6_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Id7_PM-v8.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Id7_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Id8_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Id8_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Id9_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Id9_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Ig1_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Ig1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Ig2_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Ig2_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Ig3_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Ig3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-MFG1_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-MFG1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-MFG2_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-MFG2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-OP1_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-OP1_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-OP2_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-OP2_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-OP3_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-OP3_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-OP4_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-OP4_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-OP5_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-OP5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-OP6_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-OP6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-OP7_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-OP7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-OP8_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-OP8_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-OP9_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-OP9_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-PF_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-PF_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-PFcm_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-PFcm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-PFm_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-PFm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-PFop_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-PFop_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-PFt_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-PFt_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-PGa_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-PGa_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-PGp_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-PGp_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Ph1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Ph1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Ph2_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Ph2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Ph3_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Ph3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-SFS1_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-SFS1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-SFS2_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-SFS2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-STS1_PM-v5.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-STS1_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-STS2_PM-v5.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-STS2_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-TE-1.0_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-TE-1.0_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-TE-1.1_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-TE-1.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-TE-1.2_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-TE-1.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-TE-2.1_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-TE-2.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-TE-2.2_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-TE-2.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-TE-3_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-TE-3_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-TI_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-TI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-TPJ_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-TPJ_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-TeI_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-TeI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hIP1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hIP1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hIP2_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hIP2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hIP3_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hIP3_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hIP4_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hIP4_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hIP5_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hIP5_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hIP6_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hIP6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hIP7_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hIP7_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hIP8_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hIP8_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hOc1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hOc1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hOc2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hOc2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hOc3d_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hOc3d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hOc3v_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hOc3v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hOc4d_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hOc4d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hOc4la_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hOc4la_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hOc4lp_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hOc4lp_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hOc4v_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hOc4v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hOc5_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hOc5_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hOc6_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hOc6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hPO1_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hPO1_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-p24ab.p24a_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-p24ab.p24a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-p24ab.p24b_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-p24ab.p24b_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-p24ab_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-p24ab_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-p24c.pd24cd_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-p24c.pd24cd_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-p24c.pd24cv_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-p24c.pd24cv_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-p24c.pv24c_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-p24c.pv24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-p24c_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-p24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-p32_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-p32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-s24.s24a_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-s24.s24a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-s24.s24b_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-s24.s24b_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-s24_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-s24_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-s32_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-s32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_BST_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_BST_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_CA1_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_CA1_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_CA2_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_CA2_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_CA3_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_CA3_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_CGL_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_CGL_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_CGM_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_CGM_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_CM.AAA_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_CM.AAA_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_CM.Ce_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_CM.Ce_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_CM.Me_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_CM.Me_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_CM_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_CM_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Ch-123_PM-v4.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Ch-123_PM-v4.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Ch-4_PM-v4.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Ch-4_PM-v4.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_DG_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_DG_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Dorsal-Dentate-Nucleus_PM-v6.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Dorsal-Dentate-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Entorhinal-Cortex_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Entorhinal-Cortex_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Fastigial-Nucleus_PM-v6.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Fastigial-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Frontal-II_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Frontal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Frontal-I_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Frontal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Frontal-to-Occipital_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Frontal-to-Occipital_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Frontal-to-Temporal-II_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Frontal-to-Temporal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Frontal-to-Temporal-I_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Frontal-to-Temporal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_FuCd_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_FuCd_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_FuP_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_FuP_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_HATA_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_HATA_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_HC-Transsubiculum_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_HC-Transsubiculum_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_IF.ice_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_IF.ice_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_IF.iol_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_IF.iol_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_IF.ld_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_IF.ld_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_IF_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_IF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Interposed-Nucleus_PM-v6.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Interposed-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_LB.Bl_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_LB.Bl_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_LB.Bm_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_LB.Bm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_LB.La_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_LB.La_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_LB.Pl_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_LB.Pl_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_LB_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_LB_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_MF.icm_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_MF.icm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_MF.lm_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_MF.lm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_MF_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_MF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_SF.AHi_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_SF.AHi_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_SF.APir_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_SF.APir_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_SF.VCo_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_SF.VCo_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_SF_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_SF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_STN_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_STN_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Subiculum.PaS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Subiculum.PaS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Subiculum.PreS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Subiculum.PreS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Subiculum.ProS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Subiculum.ProS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Subiculum.Sub_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Subiculum.Sub_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Temporal-to-Parietal_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Temporal-to-Parietal_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Terminal-islands_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Terminal-islands_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Tuberculum_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Tuberculum_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_VP_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_VP_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_VTM_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_VTM_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Ventral-Dentate-Nucleus_PM-v6.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Ventral-Dentate-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-1_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-1_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-25_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-25_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-2_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-33_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-33_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-3a_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-3a_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-3b_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-3b_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-44_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-44_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-45_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-45_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-4a_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-4a_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-4p_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-4p_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-5Ci_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-5Ci_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-5L_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-5L_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-5M_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-5M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-6d1_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-6d1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-6d2_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-6d2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-6d3_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-6d3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-6ma_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-6ma_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-6mp_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-6mp_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-7A_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-7A_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-7M_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-7M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-7PC_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-7PC_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-7P_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-7P_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-8d1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-8d1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-8d2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-8d2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-8v1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-8v1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-8v2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-8v2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-CoS1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-CoS1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-FG1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-FG1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-FG2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-FG2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-FG3_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-FG3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-FG4_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-FG4_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Fo1_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Fo1_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Fo2_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Fo2_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Fo3_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Fo3_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Fo4_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Fo4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Fo5_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Fo5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Fo6_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Fo6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Fo7_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Fo7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Fp1_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Fp1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Fp2_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Fp2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-IFJ1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-IFJ1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-IFJ2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-IFJ2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-IFS1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-IFS1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-IFS2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-IFS2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-IFS3_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-IFS3_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-IFS4_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-IFS4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Ia1_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Ia1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Ia2_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Ia2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Ia3_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Ia3_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Id10_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Id10_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Id1_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Id1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Id2_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Id2_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Id3_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Id3_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Id4_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Id4_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Id5_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Id5_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Id6_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Id6_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Id7_PM-v8.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Id7_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Id8_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Id8_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Id9_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Id9_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Ig1_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Ig1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Ig2_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Ig2_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Ig3_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Ig3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-MFG1_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-MFG1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-MFG2_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-MFG2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-OP1_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-OP1_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-OP2_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-OP2_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-OP3_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-OP3_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-OP4_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-OP4_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-OP5_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-OP5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-OP6_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-OP6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-OP7_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-OP7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-OP8_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-OP8_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-OP9_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-OP9_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-PF_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-PF_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-PFcm_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-PFcm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-PFm_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-PFm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-PFop_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-PFop_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-PFt_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-PFt_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-PGa_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-PGa_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-PGp_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-PGp_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Ph1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Ph1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Ph2_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Ph2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Ph3_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Ph3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-SFS1_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-SFS1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-SFS2_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-SFS2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-STS1_PM-v5.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-STS1_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-STS2_PM-v5.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-STS2_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-TE-1.0_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-TE-1.0_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-TE-1.1_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-TE-1.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-TE-1.2_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-TE-1.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-TE-2.1_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-TE-2.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-TE-2.2_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-TE-2.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-TE-3_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-TE-3_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-TI_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-TI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-TPJ_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-TPJ_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-TeI_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-TeI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hIP1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hIP1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hIP2_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hIP2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hIP3_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hIP3_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hIP4_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hIP4_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hIP5_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hIP5_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hIP6_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hIP6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hIP7_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hIP7_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hIP8_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hIP8_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hOc1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hOc1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hOc2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hOc2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hOc3d_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hOc3d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hOc3v_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hOc3v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hOc4d_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hOc4d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hOc4la_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hOc4la_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hOc4lp_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hOc4lp_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hOc4v_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hOc4v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hOc5_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hOc5_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hOc6_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hOc6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hPO1_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hPO1_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-p24ab_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-p24ab_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-p24c_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-p24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-p32_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-p32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-s24_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-s24_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-s32_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-s32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_CA1_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_CA1_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_CA2_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_CA2_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_CA3_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_CA3_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_CGL_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_CGL_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_CGM_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_CGM_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_DG_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_DG_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Entorhinal-Cortex_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Entorhinal-Cortex_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Frontal-II_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Frontal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Frontal-I_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Frontal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Frontal-to-Occipital_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Frontal-to-Occipital_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Frontal-to-Temporal-II_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Frontal-to-Temporal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Frontal-to-Temporal-I_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Frontal-to-Temporal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_HATA_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_HATA_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_HC-Transsubiculum_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_HC-Transsubiculum_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Subiculum.PaS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Subiculum.PaS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Subiculum.PreS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Subiculum.PreS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Subiculum.ProS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Subiculum.ProS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Subiculum.Sub_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Subiculum.Sub_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Temporal-to-Parietal_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Temporal-to-Parietal_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Tuberculum_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Tuberculum_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-6d1_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-6d1_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-6d2_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-6d2_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-6d3_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-6d3_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-6ma_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-6ma_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-MFG1_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-MFG1_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-MFG2_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-MFG2_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-SFS1_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-SFS1_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-SFS2_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-SFS2_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-STS1_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-STS1_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-STS2_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-STS2_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-TE-1.0_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-TE-1.0_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-TE-1.1_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-TE-1.1_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-TE-1.2_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-TE-1.2_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-TE-3_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-TE-3_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hIP4_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hIP4_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hIP5_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hIP5_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hIP6_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hIP6_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hIP7_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hIP7_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hIP8_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hIP8_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hOc1_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hOc1_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hOc2_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hOc2_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hOc3v_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hOc3v_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hOc5_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hOc5_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hOc6_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hOc6_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hPO1_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hPO1_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_CGL.lam1_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_CGL.lam1_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_CGL.lam2_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_CGL.lam2_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_CGL.lam3_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_CGL.lam3_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_CGL.lam4_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_CGL.lam4_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_CGL.lam5_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_CGL.lam5_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_CGL.lam6_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_CGL.lam6_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_CGM.CGMd_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_CGM.CGMd_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_CGM.CGMm_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_CGM.CGMm_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_CGM.CGMv_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_CGM.CGMv_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Entorhinal-Cortex_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Entorhinal-Cortex_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_AcbL_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_AcbL_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_AcbM_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_AcbM_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-1_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-1_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-25.25a_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-25.25a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-25.25p_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-25.25p_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-25_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-25_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-2_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-33_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-33_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-3a_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-3a_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-3b_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-3b_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-44_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-44_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-45_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-45_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-4a_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-4a_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-4p_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-4p_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-5Ci_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-5Ci_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-5L_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-5L_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-5M_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-5M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-6d1_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-6d1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-6d2_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-6d2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-6d3_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-6d3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-6ma_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-6ma_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-6mp_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-6mp_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-7A_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-7A_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-7M_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-7M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-7PC_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-7PC_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-7P_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-7P_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-8d1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-8d1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-8d2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-8d2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-8v1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-8v1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-8v2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-8v2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-CoS1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-CoS1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-FG1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-FG1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-FG2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-FG2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-FG3_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-FG3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-FG4_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-FG4_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Fo1_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Fo1_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Fo2_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Fo2_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Fo3_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Fo3_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Fo4_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Fo4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Fo5_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Fo5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Fo6_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Fo6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Fo7_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Fo7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Fp1_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Fp1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Fp2_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Fp2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-IFJ1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-IFJ1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-IFJ2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-IFJ2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-IFS1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-IFS1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-IFS2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-IFS2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-IFS3_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-IFS3_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-IFS4_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-IFS4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Ia1_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Ia1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Ia2_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Ia2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Ia3_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Ia3_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Id10_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Id10_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Id1_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Id1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Id2_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Id2_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Id3_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Id3_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Id4_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Id4_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Id5_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Id5_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Id6_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Id6_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Id7_PM-v8.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Id7_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Id8_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Id8_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Id9_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Id9_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Ig1_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Ig1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Ig2_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Ig2_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Ig3_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Ig3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-MFG1_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-MFG1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-MFG2_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-MFG2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-OP1_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-OP1_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-OP2_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-OP2_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-OP3_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-OP3_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-OP4_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-OP4_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-OP5_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-OP5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-OP6_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-OP6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-OP7_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-OP7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-OP8_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-OP8_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-OP9_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-OP9_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-PF_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-PF_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-PFcm_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-PFcm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-PFm_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-PFm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-PFop_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-PFop_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-PFt_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-PFt_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-PGa_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-PGa_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-PGp_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-PGp_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Ph1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Ph1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Ph2_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Ph2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Ph3_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Ph3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-SFS1_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-SFS1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-SFS2_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-SFS2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-STS1_PM-v5.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-STS1_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-STS2_PM-v5.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-STS2_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-TE-1.0_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-TE-1.0_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-TE-1.1_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-TE-1.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-TE-1.2_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-TE-1.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-TE-2.1_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-TE-2.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-TE-2.2_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-TE-2.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-TE-3_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-TE-3_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-TI_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-TI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-TPJ_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-TPJ_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-TeI_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-TeI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hIP1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hIP1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hIP2_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hIP2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hIP3_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hIP3_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hIP4_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hIP4_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hIP5_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hIP5_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hIP6_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hIP6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hIP7_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hIP7_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hIP8_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hIP8_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hOc1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hOc1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hOc2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hOc2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hOc3d_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hOc3d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hOc3v_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hOc3v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hOc4d_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hOc4d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hOc4la_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hOc4la_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hOc4lp_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hOc4lp_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hOc4v_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hOc4v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hOc5_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hOc5_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hOc6_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hOc6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hPO1_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hPO1_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-p24ab.p24a_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-p24ab.p24a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-p24ab.p24b_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-p24ab.p24b_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-p24ab_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-p24ab_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-p24c.pd24cd_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-p24c.pd24cd_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-p24c.pd24cv_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-p24c.pd24cv_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-p24c.pv24c_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-p24c.pv24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-p24c_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-p24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-p32_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-p32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-s24.s24a_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-s24.s24a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-s24.s24b_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-s24.s24b_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-s24_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-s24_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-s32_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-s32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_BST_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_BST_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_CA1_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_CA1_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_CA2_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_CA2_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_CA3_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_CA3_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_CGL_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_CGL_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_CGM_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_CGM_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_CM.AAA_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_CM.AAA_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_CM.Ce_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_CM.Ce_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_CM.Me_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_CM.Me_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_CM_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_CM_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Ch-123_PM-v4.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Ch-123_PM-v4.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Ch-4_PM-v4.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Ch-4_PM-v4.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_DG_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_DG_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Dorsal-Dentate-Nucleus_PM-v6.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Dorsal-Dentate-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Entorhinal-Cortex_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Entorhinal-Cortex_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Fastigial-Nucleus_PM-v6.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Fastigial-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Frontal-II_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Frontal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Frontal-I_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Frontal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Frontal-to-Occipital_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Frontal-to-Occipital_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Frontal-to-Temporal-II_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Frontal-to-Temporal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Frontal-to-Temporal-I_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Frontal-to-Temporal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_FuCd_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_FuCd_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_FuP_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_FuP_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_HATA_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_HATA_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_HC-Transsubiculum_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_HC-Transsubiculum_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_IF.ice_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_IF.ice_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_IF.iol_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_IF.iol_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_IF.ld_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_IF.ld_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_IF_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_IF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Interposed-Nucleus_PM-v6.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Interposed-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_LB.Bl_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_LB.Bl_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_LB.Bm_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_LB.Bm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_LB.La_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_LB.La_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_LB.Pl_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_LB.Pl_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_LB_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_LB_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_MF.icm_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_MF.icm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_MF.lm_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_MF.lm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_MF_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_MF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_SF.AHi_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_SF.AHi_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_SF.APir_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_SF.APir_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_SF.VCo_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_SF.VCo_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_SF_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_SF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_STN_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_STN_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Subiculum.PaS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Subiculum.PaS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Subiculum.PreS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Subiculum.PreS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Subiculum.ProS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Subiculum.ProS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Subiculum.Sub_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Subiculum.Sub_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Temporal-to-Parietal_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Temporal-to-Parietal_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Terminal-islands_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Terminal-islands_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Tuberculum_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Tuberculum_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_VP_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_VP_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_VTM_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_VTM_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Ventral-Dentate-Nucleus_PM-v6.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Ventral-Dentate-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_AcbL_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_AcbL_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_AcbM_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_AcbM_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-1_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-1_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-25.25a_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-25.25a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-25.25p_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-25.25p_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-25_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-25_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-2_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-33_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-33_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-3a_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-3a_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-3b_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-3b_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-44_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-44_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-45_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-45_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-4a_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-4a_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-4p_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-4p_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-5Ci_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-5Ci_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-5L_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-5L_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-5M_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-5M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-6d1_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-6d1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-6d2_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-6d2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-6d3_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-6d3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-6ma_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-6ma_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-6mp_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-6mp_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-7A_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-7A_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-7M_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-7M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-7PC_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-7PC_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-7P_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-7P_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-8d1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-8d1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-8d2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-8d2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-8v1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-8v1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-8v2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-8v2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-CoS1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-CoS1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-FG1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-FG1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-FG2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-FG2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-FG3_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-FG3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-FG4_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-FG4_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Fo1_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Fo1_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Fo2_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Fo2_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Fo3_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Fo3_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Fo4_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Fo4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Fo5_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Fo5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Fo6_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Fo6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Fo7_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Fo7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Fp1_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Fp1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Fp2_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Fp2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-IFJ1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-IFJ1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-IFJ2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-IFJ2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-IFS1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-IFS1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-IFS2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-IFS2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-IFS3_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-IFS3_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-IFS4_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-IFS4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Ia1_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Ia1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Ia2_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Ia2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Ia3_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Ia3_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Id10_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Id10_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Id1_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Id1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Id2_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Id2_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Id3_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Id3_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Id4_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Id4_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Id5_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Id5_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Id6_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Id6_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Id7_PM-v8.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Id7_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Id8_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Id8_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Id9_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Id9_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Ig1_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Ig1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Ig2_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Ig2_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Ig3_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Ig3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-MFG1_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-MFG1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-MFG2_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-MFG2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-OP1_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-OP1_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-OP2_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-OP2_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-OP3_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-OP3_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-OP4_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-OP4_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-OP5_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-OP5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-OP6_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-OP6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-OP7_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-OP7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-OP8_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-OP8_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-OP9_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-OP9_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-PF_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-PF_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-PFcm_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-PFcm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-PFm_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-PFm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-PFop_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-PFop_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-PFt_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-PFt_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-PGa_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-PGa_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-PGp_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-PGp_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Ph1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Ph1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Ph2_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Ph2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Ph3_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Ph3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-SFS1_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-SFS1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-SFS2_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-SFS2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-STS1_PM-v5.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-STS1_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-STS2_PM-v5.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-STS2_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-TE-1.0_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-TE-1.0_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-TE-1.1_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-TE-1.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-TE-1.2_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-TE-1.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-TE-2.1_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-TE-2.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-TE-2.2_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-TE-2.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-TE-3_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-TE-3_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-TI_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-TI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-TPJ_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-TPJ_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-TeI_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-TeI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hIP1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hIP1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hIP2_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hIP2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hIP3_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hIP3_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hIP4_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hIP4_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hIP5_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hIP5_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hIP6_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hIP6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hIP7_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hIP7_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hIP8_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hIP8_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hOc1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hOc1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hOc2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hOc2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hOc3d_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hOc3d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hOc3v_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hOc3v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hOc4d_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hOc4d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hOc4la_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hOc4la_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hOc4lp_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hOc4lp_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hOc4v_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hOc4v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hOc5_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hOc5_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hOc6_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hOc6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hPO1_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hPO1_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-p24ab.p24a_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-p24ab.p24a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-p24ab.p24b_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-p24ab.p24b_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-p24ab_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-p24ab_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-p24c.pd24cd_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-p24c.pd24cd_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-p24c.pd24cv_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-p24c.pd24cv_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-p24c.pv24c_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-p24c.pv24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-p24c_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-p24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-p32_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-p32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-s24.s24a_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-s24.s24a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-s24.s24b_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-s24.s24b_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-s24_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-s24_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-s32_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-s32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_BST_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_BST_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_CA1_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_CA1_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_CA2_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_CA2_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_CA3_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_CA3_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_CGL_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_CGL_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_CGM_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_CGM_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_CM.AAA_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_CM.AAA_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_CM.Ce_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_CM.Ce_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_CM.Me_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_CM.Me_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_CM_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_CM_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Ch-123_PM-v4.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Ch-123_PM-v4.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Ch-4_PM-v4.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Ch-4_PM-v4.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_DG_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_DG_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Dorsal-Dentate-Nucleus_PM-v6.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Dorsal-Dentate-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Entorhinal-Cortex_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Entorhinal-Cortex_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Fastigial-Nucleus_PM-v6.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Fastigial-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Frontal-II_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Frontal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Frontal-I_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Frontal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Frontal-to-Occipital_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Frontal-to-Occipital_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Frontal-to-Temporal-II_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Frontal-to-Temporal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Frontal-to-Temporal-I_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Frontal-to-Temporal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_FuCd_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_FuCd_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_FuP_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_FuP_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_HATA_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_HATA_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_HC-Transsubiculum_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_HC-Transsubiculum_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_IF.ice_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_IF.ice_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_IF.iol_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_IF.iol_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_IF.ld_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_IF.ld_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_IF_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_IF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Interposed-Nucleus_PM-v6.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Interposed-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_LB.Bl_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_LB.Bl_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_LB.Bm_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_LB.Bm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_LB.La_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_LB.La_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_LB.Pl_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_LB.Pl_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_LB_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_LB_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_MF.icm_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_MF.icm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_MF.lm_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_MF.lm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_MF_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_MF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_SF.AHi_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_SF.AHi_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_SF.APir_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_SF.APir_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_SF.VCo_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_SF.VCo_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_SF_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_SF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_STN_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_STN_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Subiculum.PaS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Subiculum.PaS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Subiculum.PreS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Subiculum.PreS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Subiculum.ProS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Subiculum.ProS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Subiculum.Sub_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Subiculum.Sub_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Temporal-to-Parietal_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Temporal-to-Parietal_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Terminal-islands_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Terminal-islands_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Tuberculum_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Tuberculum_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_VP_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_VP_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_VTM_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_VTM_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Ventral-Dentate-Nucleus_PM-v6.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Ventral-Dentate-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-1_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-1_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-25_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-25_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-2_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-33_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-33_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-3a_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-3a_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-3b_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-3b_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-44_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-44_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-45_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-45_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-4a_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-4a_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-4p_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-4p_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-5Ci_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-5Ci_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-5L_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-5L_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-5M_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-5M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-6d1_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-6d1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-6d2_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-6d2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-6d3_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-6d3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-6ma_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-6ma_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-6mp_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-6mp_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-7A_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-7A_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-7M_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-7M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-7PC_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-7PC_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-7P_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-7P_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-8d1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-8d1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-8d2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-8d2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-8v1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-8v1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-8v2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-8v2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-CoS1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-CoS1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-FG1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-FG1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-FG2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-FG2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-FG3_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-FG3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-FG4_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-FG4_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Fo1_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Fo1_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Fo2_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Fo2_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Fo3_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Fo3_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Fo4_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Fo4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Fo5_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Fo5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Fo6_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Fo6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Fo7_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Fo7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Fp1_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Fp1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Fp2_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Fp2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-IFJ1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-IFJ1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-IFJ2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-IFJ2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-IFS1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-IFS1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-IFS2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-IFS2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-IFS3_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-IFS3_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-IFS4_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-IFS4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Ia1_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Ia1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Ia2_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Ia2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Ia3_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Ia3_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Id10_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Id10_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Id1_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Id1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Id2_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Id2_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Id3_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Id3_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Id4_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Id4_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Id5_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Id5_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Id6_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Id6_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Id7_PM-v8.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Id7_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Id8_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Id8_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Id9_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Id9_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Ig1_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Ig1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Ig2_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Ig2_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Ig3_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Ig3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-MFG1_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-MFG1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-MFG2_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-MFG2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-OP1_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-OP1_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-OP2_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-OP2_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-OP3_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-OP3_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-OP4_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-OP4_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-OP5_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-OP5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-OP6_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-OP6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-OP7_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-OP7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-OP8_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-OP8_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-OP9_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-OP9_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-PF_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-PF_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-PFcm_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-PFcm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-PFm_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-PFm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-PFop_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-PFop_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-PFt_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-PFt_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-PGa_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-PGa_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-PGp_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-PGp_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Ph1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Ph1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Ph2_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Ph2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Ph3_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Ph3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-SFS1_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-SFS1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-SFS2_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-SFS2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-STS1_PM-v5.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-STS1_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-STS2_PM-v5.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-STS2_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-TE-1.0_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-TE-1.0_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-TE-1.1_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-TE-1.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-TE-1.2_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-TE-1.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-TE-2.1_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-TE-2.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-TE-2.2_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-TE-2.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-TE-3_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-TE-3_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-TI_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-TI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-TPJ_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-TPJ_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-TeI_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-TeI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hIP1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hIP1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hIP2_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hIP2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hIP3_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hIP3_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hIP4_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hIP4_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hIP5_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hIP5_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hIP6_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hIP6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hIP7_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hIP7_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hIP8_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hIP8_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hOc1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hOc1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hOc2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hOc2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hOc3d_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hOc3d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hOc3v_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hOc3v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hOc4d_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hOc4d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hOc4la_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hOc4la_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hOc4lp_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hOc4lp_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hOc4v_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hOc4v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hOc5_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hOc5_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hOc6_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hOc6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hPO1_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hPO1_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-p24ab_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-p24ab_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-p24c_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-p24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-p32_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-p32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-s24_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-s24_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-s32_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-s32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_CA1_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_CA1_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_CA2_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_CA2_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_CA3_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_CA3_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_CGL_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_CGL_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_CGM_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_CGM_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_DG_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_DG_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Entorhinal-Cortex_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Entorhinal-Cortex_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Frontal-II_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Frontal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Frontal-I_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Frontal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Frontal-to-Occipital_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Frontal-to-Occipital_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Frontal-to-Temporal-II_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Frontal-to-Temporal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Frontal-to-Temporal-I_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Frontal-to-Temporal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_HATA_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_HATA_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_HC-Transsubiculum_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_HC-Transsubiculum_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Subiculum.PaS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Subiculum.PaS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Subiculum.PreS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Subiculum.PreS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Subiculum.ProS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Subiculum.ProS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Subiculum.Sub_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Subiculum.Sub_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Temporal-to-Parietal_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Temporal-to-Parietal_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Tuberculum_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Tuberculum_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-6d1_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-6d1_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-6d2_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-6d2_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-6d3_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-6d3_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-6ma_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-6ma_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-MFG1_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-MFG1_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-MFG2_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-MFG2_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-SFS1_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-SFS1_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-SFS2_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-SFS2_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-STS1_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-STS1_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-STS2_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-STS2_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-TE-1.0_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-TE-1.0_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-TE-1.1_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-TE-1.1_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-TE-1.2_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-TE-1.2_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-TE-3_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-TE-3_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hIP4_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hIP4_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hIP5_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hIP5_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hIP6_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hIP6_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hIP7_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hIP7_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hIP8_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hIP8_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hOc1_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hOc1_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hOc2_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hOc2_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hOc3v_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hOc3v_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hOc5_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hOc5_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hOc6_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hOc6_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hPO1_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hPO1_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_CGL.lam1_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_CGL.lam1_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_CGL.lam2_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_CGL.lam2_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_CGL.lam3_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_CGL.lam3_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_CGL.lam4_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_CGL.lam4_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_CGL.lam5_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_CGL.lam5_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_CGL.lam6_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_CGL.lam6_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_CGM.CGMd_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_CGM.CGMd_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_CGM.CGMm_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_CGM.CGMm_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_CGM.CGMv_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_CGM.CGMv_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Entorhinal-Cortex_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Entorhinal-Cortex_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_AcbL_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_AcbL_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_AcbM_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_AcbM_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-1_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-1_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-25.25a_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-25.25a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-25.25p_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-25.25p_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-25_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-25_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-2_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-33_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-33_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-3a_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-3a_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-3b_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-3b_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-44_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-44_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-45_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-45_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-4a_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-4a_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-4p_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-4p_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-5Ci_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-5Ci_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-5L_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-5L_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-5M_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-5M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-6d1_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-6d1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-6d2_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-6d2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-6d3_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-6d3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-6ma_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-6ma_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-6mp_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-6mp_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-7A_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-7A_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-7M_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-7M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-7PC_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-7PC_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-7P_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-7P_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-8d1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-8d1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-8d2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-8d2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-8v1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-8v1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-8v2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-8v2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-CoS1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-CoS1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-FG1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-FG1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-FG2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-FG2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-FG3_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-FG3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-FG4_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-FG4_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Fo1_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Fo1_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Fo2_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Fo2_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Fo3_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Fo3_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Fo4_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Fo4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Fo5_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Fo5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Fo6_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Fo6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Fo7_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Fo7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Fp1_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Fp1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Fp2_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Fp2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-IFJ1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-IFJ1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-IFJ2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-IFJ2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-IFS1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-IFS1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-IFS2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-IFS2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-IFS3_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-IFS3_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-IFS4_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-IFS4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Ia1_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Ia1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Ia2_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Ia2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Ia3_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Ia3_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Id10_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Id10_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Id1_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Id1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Id2_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Id2_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Id3_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Id3_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Id4_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Id4_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Id5_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Id5_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Id6_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Id6_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Id7_PM-v8.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Id7_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Id8_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Id8_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Id9_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Id9_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Ig1_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Ig1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Ig2_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Ig2_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Ig3_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Ig3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-MFG1_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-MFG1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-MFG2_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-MFG2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-OP1_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-OP1_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-OP2_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-OP2_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-OP3_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-OP3_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-OP4_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-OP4_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-OP5_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-OP5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-OP6_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-OP6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-OP7_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-OP7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-OP8_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-OP8_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-OP9_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-OP9_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-PF_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-PF_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-PFcm_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-PFcm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-PFm_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-PFm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-PFop_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-PFop_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-PFt_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-PFt_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-PGa_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-PGa_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-PGp_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-PGp_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Ph1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Ph1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Ph2_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Ph2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Ph3_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Ph3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-SFS1_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-SFS1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-SFS2_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-SFS2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-STS1_PM-v5.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-STS1_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-STS2_PM-v5.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-STS2_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-TE-1.0_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-TE-1.0_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-TE-1.1_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-TE-1.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-TE-1.2_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-TE-1.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-TE-2.1_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-TE-2.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-TE-2.2_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-TE-2.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-TE-3_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-TE-3_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-TI_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-TI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-TPJ_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-TPJ_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-TeI_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-TeI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hIP1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hIP1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hIP2_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hIP2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hIP3_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hIP3_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hIP4_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hIP4_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hIP5_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hIP5_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hIP6_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hIP6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hIP7_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hIP7_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hIP8_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hIP8_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hOc1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hOc1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hOc2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hOc2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hOc3d_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hOc3d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hOc3v_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hOc3v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hOc4d_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hOc4d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hOc4la_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hOc4la_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hOc4lp_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hOc4lp_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hOc4v_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hOc4v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hOc5_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hOc5_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hOc6_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hOc6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hPO1_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hPO1_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-p24ab.p24a_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-p24ab.p24a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-p24ab.p24b_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-p24ab.p24b_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-p24ab_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-p24ab_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-p24c.pd24cd_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-p24c.pd24cd_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-p24c.pd24cv_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-p24c.pd24cv_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-p24c.pv24c_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-p24c.pv24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-p24c_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-p24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-p32_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-p32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-s24.s24a_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-s24.s24a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-s24.s24b_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-s24.s24b_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-s24_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-s24_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-s32_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-s32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_BST_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_BST_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_CA1_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_CA1_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_CA2_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_CA2_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_CA3_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_CA3_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_CGL_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_CGL_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_CGM_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_CGM_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_CM.AAA_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_CM.AAA_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_CM.Ce_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_CM.Ce_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_CM.Me_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_CM.Me_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_CM_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_CM_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Ch-123_PM-v4.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Ch-123_PM-v4.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Ch-4_PM-v4.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Ch-4_PM-v4.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_DG_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_DG_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Dorsal-Dentate-Nucleus_PM-v6.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Dorsal-Dentate-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Entorhinal-Cortex_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Entorhinal-Cortex_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Fastigial-Nucleus_PM-v6.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Fastigial-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Frontal-II_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Frontal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Frontal-I_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Frontal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Frontal-to-Occipital_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Frontal-to-Occipital_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Frontal-to-Temporal-II_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Frontal-to-Temporal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Frontal-to-Temporal-I_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Frontal-to-Temporal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_FuCd_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_FuCd_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_FuP_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_FuP_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_HATA_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_HATA_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_HC-Transsubiculum_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_HC-Transsubiculum_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_IF.ice_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_IF.ice_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_IF.iol_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_IF.iol_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_IF.ld_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_IF.ld_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_IF_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_IF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Interposed-Nucleus_PM-v6.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Interposed-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_LB.Bl_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_LB.Bl_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_LB.Bm_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_LB.Bm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_LB.La_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_LB.La_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_LB.Pl_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_LB.Pl_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_LB_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_LB_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_MF.icm_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_MF.icm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_MF.lm_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_MF.lm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_MF_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_MF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_SF.AHi_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_SF.AHi_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_SF.APir_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_SF.APir_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_SF.VCo_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_SF.VCo_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_SF_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_SF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_STN_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_STN_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Subiculum.PaS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Subiculum.PaS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Subiculum.PreS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Subiculum.PreS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Subiculum.ProS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Subiculum.ProS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Subiculum.Sub_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Subiculum.Sub_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Temporal-to-Parietal_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Temporal-to-Parietal_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Terminal-islands_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Terminal-islands_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Tuberculum_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Tuberculum_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_VP_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_VP_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_VTM_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_VTM_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Ventral-Dentate-Nucleus_PM-v6.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Ventral-Dentate-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_AcbL_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_AcbL_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_AcbM_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_AcbM_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-1_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-1_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-25.25a_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-25.25a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-25.25p_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-25.25p_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-25_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-25_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-2_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-33_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-33_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-3a_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-3a_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-3b_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-3b_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-44_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-44_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-45_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-45_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-4a_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-4a_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-4p_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-4p_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-5Ci_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-5Ci_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-5L_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-5L_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-5M_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-5M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-6d1_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-6d1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-6d2_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-6d2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-6d3_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-6d3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-6ma_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-6ma_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-6mp_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-6mp_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-7A_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-7A_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-7M_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-7M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-7PC_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-7PC_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-7P_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-7P_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-8d1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-8d1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-8d2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-8d2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-8v1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-8v1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-8v2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-8v2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-CoS1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-CoS1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-FG1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-FG1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-FG2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-FG2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-FG3_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-FG3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-FG4_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-FG4_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Fo1_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Fo1_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Fo2_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Fo2_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Fo3_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Fo3_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Fo4_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Fo4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Fo5_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Fo5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Fo6_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Fo6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Fo7_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Fo7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Fp1_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Fp1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Fp2_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Fp2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-IFJ1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-IFJ1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-IFJ2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-IFJ2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-IFS1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-IFS1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-IFS2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-IFS2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-IFS3_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-IFS3_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-IFS4_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-IFS4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Ia1_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Ia1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Ia2_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Ia2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Ia3_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Ia3_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Id10_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Id10_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Id1_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Id1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Id2_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Id2_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Id3_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Id3_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Id4_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Id4_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Id5_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Id5_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Id6_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Id6_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Id7_PM-v8.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Id7_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Id8_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Id8_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Id9_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Id9_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Ig1_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Ig1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Ig2_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Ig2_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Ig3_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Ig3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-MFG1_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-MFG1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-MFG2_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-MFG2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-OP1_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-OP1_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-OP2_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-OP2_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-OP3_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-OP3_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-OP4_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-OP4_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-OP5_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-OP5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-OP6_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-OP6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-OP7_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-OP7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-OP8_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-OP8_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-OP9_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-OP9_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-PF_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-PF_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-PFcm_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-PFcm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-PFm_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-PFm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-PFop_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-PFop_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-PFt_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-PFt_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-PGa_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-PGa_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-PGp_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-PGp_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Ph1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Ph1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Ph2_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Ph2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Ph3_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Ph3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-SFS1_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-SFS1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-SFS2_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-SFS2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-STS1_PM-v5.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-STS1_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-STS2_PM-v5.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-STS2_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-TE-1.0_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-TE-1.0_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-TE-1.1_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-TE-1.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-TE-1.2_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-TE-1.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-TE-2.1_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-TE-2.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-TE-2.2_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-TE-2.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-TE-3_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-TE-3_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-TI_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-TI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-TPJ_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-TPJ_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-TeI_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-TeI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hIP1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hIP1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hIP2_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hIP2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hIP3_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hIP3_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hIP4_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hIP4_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hIP5_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hIP5_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hIP6_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hIP6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hIP7_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hIP7_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hIP8_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hIP8_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hOc1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hOc1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hOc2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hOc2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hOc3d_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hOc3d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hOc3v_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hOc3v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hOc4d_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hOc4d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hOc4la_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hOc4la_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hOc4lp_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hOc4lp_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hOc4v_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hOc4v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hOc5_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hOc5_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hOc6_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hOc6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hPO1_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hPO1_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-p24ab.p24a_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-p24ab.p24a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-p24ab.p24b_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-p24ab.p24b_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-p24ab_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-p24ab_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-p24c.pd24cd_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-p24c.pd24cd_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-p24c.pd24cv_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-p24c.pd24cv_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-p24c.pv24c_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-p24c.pv24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-p24c_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-p24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-p32_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-p32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-s24.s24a_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-s24.s24a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-s24.s24b_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-s24.s24b_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-s24_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-s24_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-s32_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-s32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_BST_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_BST_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_CA1_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_CA1_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_CA2_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_CA2_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_CA3_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_CA3_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_CGL_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_CGL_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_CGM_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_CGM_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_CM.AAA_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_CM.AAA_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_CM.Ce_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_CM.Ce_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_CM.Me_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_CM.Me_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_CM_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_CM_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Ch-123_PM-v4.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Ch-123_PM-v4.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Ch-4_PM-v4.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Ch-4_PM-v4.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_DG_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_DG_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Dorsal-Dentate-Nucleus_PM-v6.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Dorsal-Dentate-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Entorhinal-Cortex_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Entorhinal-Cortex_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Fastigial-Nucleus_PM-v6.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Fastigial-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Frontal-II_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Frontal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Frontal-I_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Frontal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Frontal-to-Occipital_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Frontal-to-Occipital_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Frontal-to-Temporal-II_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Frontal-to-Temporal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Frontal-to-Temporal-I_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Frontal-to-Temporal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_FuCd_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_FuCd_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_FuP_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_FuP_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_HATA_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_HATA_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_HC-Transsubiculum_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_HC-Transsubiculum_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_IF.ice_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_IF.ice_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_IF.iol_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_IF.iol_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_IF.ld_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_IF.ld_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_IF_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_IF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Interposed-Nucleus_PM-v6.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Interposed-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_LB.Bl_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_LB.Bl_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_LB.Bm_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_LB.Bm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_LB.La_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_LB.La_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_LB.Pl_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_LB.Pl_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_LB_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_LB_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_MF.icm_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_MF.icm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_MF.lm_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_MF.lm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_MF_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_MF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_SF.AHi_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_SF.AHi_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_SF.APir_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_SF.APir_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_SF.VCo_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_SF.VCo_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_SF_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_SF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_STN_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_STN_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Subiculum.PaS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Subiculum.PaS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Subiculum.PreS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Subiculum.PreS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Subiculum.ProS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Subiculum.ProS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Subiculum.Sub_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Subiculum.Sub_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Temporal-to-Parietal_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Temporal-to-Parietal_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Terminal-islands_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Terminal-islands_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Tuberculum_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Tuberculum_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_VP_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_VP_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_VTM_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_VTM_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Ventral-Dentate-Nucleus_PM-v6.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Ventral-Dentate-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-1_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-1_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-25_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-25_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-2_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-33_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-33_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-3a_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-3a_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-3b_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-3b_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-44_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-44_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-45_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-45_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-4a_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-4a_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-4p_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-4p_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-5Ci_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-5Ci_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-5L_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-5L_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-5M_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-5M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-6d1_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-6d1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-6d2_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-6d2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-6d3_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-6d3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-6ma_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-6ma_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-6mp_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-6mp_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-7A_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-7A_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-7M_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-7M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-7PC_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-7PC_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-7P_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-7P_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-8d1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-8d1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-8d2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-8d2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-8v1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-8v1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-8v2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-8v2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-CoS1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-CoS1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-FG1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-FG1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-FG2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-FG2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-FG3_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-FG3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-FG4_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-FG4_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Fo1_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Fo1_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Fo2_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Fo2_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Fo3_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Fo3_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Fo4_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Fo4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Fo5_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Fo5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Fo6_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Fo6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Fo7_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Fo7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Fp1_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Fp1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Fp2_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Fp2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-IFJ1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-IFJ1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-IFJ2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-IFJ2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-IFS1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-IFS1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-IFS2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-IFS2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-IFS3_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-IFS3_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-IFS4_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-IFS4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Ia1_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Ia1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Ia2_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Ia2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Ia3_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Ia3_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Id10_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Id10_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Id1_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Id1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Id2_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Id2_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Id3_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Id3_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Id4_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Id4_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Id5_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Id5_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Id6_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Id6_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Id7_PM-v8.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Id7_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Id8_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Id8_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Id9_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Id9_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Ig1_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Ig1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Ig2_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Ig2_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Ig3_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Ig3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-MFG1_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-MFG1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-MFG2_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-MFG2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-OP1_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-OP1_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-OP2_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-OP2_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-OP3_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-OP3_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-OP4_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-OP4_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-OP5_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-OP5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-OP6_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-OP6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-OP7_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-OP7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-OP8_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-OP8_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-OP9_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-OP9_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-PF_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-PF_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-PFcm_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-PFcm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-PFm_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-PFm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-PFop_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-PFop_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-PFt_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-PFt_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-PGa_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-PGa_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-PGp_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-PGp_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Ph1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Ph1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Ph2_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Ph2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Ph3_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Ph3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-SFS1_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-SFS1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-SFS2_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-SFS2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-STS1_PM-v5.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-STS1_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-STS2_PM-v5.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-STS2_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-TE-1.0_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-TE-1.0_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-TE-1.1_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-TE-1.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-TE-1.2_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-TE-1.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-TE-2.1_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-TE-2.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-TE-2.2_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-TE-2.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-TE-3_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-TE-3_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-TI_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-TI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-TPJ_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-TPJ_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-TeI_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-TeI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hIP1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hIP1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hIP2_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hIP2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hIP3_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hIP3_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hIP4_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hIP4_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hIP5_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hIP5_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hIP6_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hIP6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hIP7_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hIP7_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hIP8_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hIP8_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hOc1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hOc1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hOc2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hOc2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hOc3d_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hOc3d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hOc3v_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hOc3v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hOc4d_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hOc4d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hOc4la_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hOc4la_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hOc4lp_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hOc4lp_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hOc4v_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hOc4v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hOc5_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hOc5_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hOc6_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hOc6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hPO1_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hPO1_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-p24ab_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-p24ab_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-p24c_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-p24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-p32_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-p32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-s24_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-s24_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-s32_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-s32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_CA1_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_CA1_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_CA2_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_CA2_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_CA3_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_CA3_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_CGL_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_CGL_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_CGM_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_CGM_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_DG_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_DG_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Entorhinal-Cortex_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Entorhinal-Cortex_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Frontal-II_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Frontal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Frontal-I_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Frontal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Frontal-to-Occipital_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Frontal-to-Occipital_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Frontal-to-Temporal-II_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Frontal-to-Temporal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Frontal-to-Temporal-I_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Frontal-to-Temporal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_HATA_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_HATA_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_HC-Transsubiculum_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_HC-Transsubiculum_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Subiculum.PaS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Subiculum.PaS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Subiculum.PreS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Subiculum.PreS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Subiculum.ProS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Subiculum.ProS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Subiculum.Sub_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Subiculum.Sub_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Temporal-to-Parietal_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Temporal-to-Parietal_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Tuberculum_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Tuberculum_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-6d1_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-6d1_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-6d2_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-6d2_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-6d3_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-6d3_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-6ma_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-6ma_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-MFG1_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-MFG1_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-MFG2_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-MFG2_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-SFS1_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-SFS1_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-SFS2_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-SFS2_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-STS1_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-STS1_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-STS2_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-STS2_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-TE-1.0_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-TE-1.0_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-TE-1.1_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-TE-1.1_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-TE-1.2_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-TE-1.2_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-TE-3_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-TE-3_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hIP4_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hIP4_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hIP5_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hIP5_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hIP6_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hIP6_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hIP7_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hIP7_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hIP8_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hIP8_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hOc1_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hOc1_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hOc2_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hOc2_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hOc3v_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hOc3v_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hOc5_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hOc5_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hOc6_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hOc6_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hPO1_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hPO1_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_CGL.lam1_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_CGL.lam1_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_CGL.lam2_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_CGL.lam2_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_CGL.lam3_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_CGL.lam3_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_CGL.lam4_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_CGL.lam4_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_CGL.lam5_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_CGL.lam5_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_CGL.lam6_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_CGL.lam6_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_CGM.CGMd_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_CGM.CGMd_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_CGM.CGMm_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_CGM.CGMm_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_CGM.CGMv_deep.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_CGM.CGMv_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Entorhinal-Cortex_int.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Entorhinal-Cortex_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_AcbL_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_AcbL_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_AcbM_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_AcbM_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-1_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-1_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-25.25a_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-25.25a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-25.25p_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-25.25p_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-25_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-25_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-2_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-33_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-33_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-3a_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-3a_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-3b_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-3b_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-44_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-44_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-45_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-45_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-4a_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-4a_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-4p_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-4p_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-5Ci_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-5Ci_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-5L_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-5L_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-5M_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-5M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-6d1_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-6d1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-6d2_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-6d2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-6d3_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-6d3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-6ma_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-6ma_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-6mp_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-6mp_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-7A_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-7A_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-7M_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-7M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-7PC_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-7PC_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-7P_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-7P_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-8d1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-8d1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-8d2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-8d2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-8v1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-8v1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-8v2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-8v2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-CoS1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-CoS1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-FG1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-FG1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-FG2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-FG2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-FG3_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-FG3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-FG4_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-FG4_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Fo1_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Fo1_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Fo2_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Fo2_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Fo3_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Fo3_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Fo4_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Fo4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Fo5_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Fo5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Fo6_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Fo6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Fo7_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Fo7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Fp1_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Fp1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Fp2_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Fp2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-IFJ1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-IFJ1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-IFJ2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-IFJ2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-IFS1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-IFS1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-IFS2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-IFS2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-IFS3_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-IFS3_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-IFS4_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-IFS4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Ia1_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Ia1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Ia2_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Ia2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Ia3_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Ia3_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Id10_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Id10_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Id1_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Id1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Id2_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Id2_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Id3_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Id3_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Id4_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Id4_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Id5_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Id5_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Id6_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Id6_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Id7_PM-v8.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Id7_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Id8_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Id8_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Id9_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Id9_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Ig1_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Ig1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Ig2_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Ig2_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Ig3_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Ig3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-MFG1_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-MFG1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-MFG2_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-MFG2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-OP1_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-OP1_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-OP2_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-OP2_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-OP3_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-OP3_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-OP4_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-OP4_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-OP5_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-OP5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-OP6_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-OP6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-OP7_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-OP7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-OP8_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-OP8_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-OP9_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-OP9_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-PF_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-PF_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-PFcm_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-PFcm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-PFm_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-PFm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-PFop_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-PFop_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-PFt_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-PFt_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-PGa_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-PGa_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-PGp_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-PGp_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Ph1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Ph1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Ph2_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Ph2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Ph3_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Ph3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-SFS1_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-SFS1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-SFS2_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-SFS2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-STS1_PM-v5.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-STS1_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-STS2_PM-v5.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-STS2_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-TE-1.0_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-TE-1.0_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-TE-1.1_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-TE-1.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-TE-1.2_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-TE-1.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-TE-2.1_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-TE-2.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-TE-2.2_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-TE-2.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-TE-3_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-TE-3_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-TI_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-TI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-TPJ_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-TPJ_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-TeI_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-TeI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hIP1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hIP1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hIP2_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hIP2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hIP3_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hIP3_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hIP4_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hIP4_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hIP5_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hIP5_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hIP6_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hIP6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hIP7_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hIP7_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hIP8_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hIP8_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hOc1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hOc1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hOc2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hOc2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hOc3d_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hOc3d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hOc3v_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hOc3v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hOc4d_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hOc4d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hOc4la_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hOc4la_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hOc4lp_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hOc4lp_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hOc4v_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hOc4v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hOc5_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hOc5_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hOc6_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hOc6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hPO1_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hPO1_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-p24ab.p24a_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-p24ab.p24a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-p24ab.p24b_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-p24ab.p24b_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-p24ab_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-p24ab_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-p24c.pd24cd_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-p24c.pd24cd_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-p24c.pd24cv_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-p24c.pd24cv_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-p24c.pv24c_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-p24c.pv24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-p24c_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-p24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-p32_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-p32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-s24.s24a_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-s24.s24a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-s24.s24b_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-s24.s24b_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-s24_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-s24_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-s32_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-s32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_BST_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_BST_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_CA1_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_CA1_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_CA2_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_CA2_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_CA3_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_CA3_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_CGL_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_CGL_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_CGM_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_CGM_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_CM.AAA_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_CM.AAA_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_CM.Ce_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_CM.Ce_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_CM.Me_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_CM.Me_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_CM_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_CM_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Ch-123_PM-v4.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Ch-123_PM-v4.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Ch-4_PM-v4.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Ch-4_PM-v4.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_DG_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_DG_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Dorsal-Dentate-Nucleus_PM-v6.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Dorsal-Dentate-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Entorhinal-Cortex_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Entorhinal-Cortex_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Fastigial-Nucleus_PM-v6.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Fastigial-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Frontal-II_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Frontal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Frontal-I_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Frontal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Frontal-to-Occipital_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Frontal-to-Occipital_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Frontal-to-Temporal-II_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Frontal-to-Temporal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Frontal-to-Temporal-I_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Frontal-to-Temporal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_FuCd_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_FuCd_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_FuP_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_FuP_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_HATA_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_HATA_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_HC-Transsubiculum_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_HC-Transsubiculum_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_IF.ice_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_IF.ice_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_IF.iol_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_IF.iol_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_IF.ld_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_IF.ld_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_IF_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_IF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Interposed-Nucleus_PM-v6.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Interposed-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_LB.Bl_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_LB.Bl_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_LB.Bm_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_LB.Bm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_LB.La_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_LB.La_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_LB.Pl_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_LB.Pl_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_LB_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_LB_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_MF.icm_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_MF.icm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_MF.lm_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_MF.lm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_MF_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_MF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_SF.AHi_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_SF.AHi_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_SF.APir_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_SF.APir_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_SF.VCo_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_SF.VCo_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_SF_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_SF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_STN_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_STN_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Subiculum.PaS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Subiculum.PaS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Subiculum.PreS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Subiculum.PreS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Subiculum.ProS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Subiculum.ProS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Subiculum.Sub_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Subiculum.Sub_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Temporal-to-Parietal_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Temporal-to-Parietal_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Terminal-islands_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Terminal-islands_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Tuberculum_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Tuberculum_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_VP_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_VP_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_VTM_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_VTM_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Ventral-Dentate-Nucleus_PM-v6.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Ventral-Dentate-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_AcbL_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_AcbL_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_AcbM_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_AcbM_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-1_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-1_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-25.25a_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-25.25a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-25.25p_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-25.25p_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-25_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-25_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-2_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-33_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-33_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-3a_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-3a_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-3b_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-3b_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-44_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-44_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-45_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-45_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-4a_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-4a_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-4p_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-4p_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-5Ci_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-5Ci_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-5L_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-5L_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-5M_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-5M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-6d1_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-6d1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-6d2_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-6d2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-6d3_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-6d3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-6ma_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-6ma_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-6mp_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-6mp_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-7A_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-7A_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-7M_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-7M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-7PC_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-7PC_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-7P_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-7P_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-8d1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-8d1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-8d2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-8d2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-8v1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-8v1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-8v2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-8v2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-CoS1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-CoS1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-FG1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-FG1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-FG2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-FG2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-FG3_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-FG3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-FG4_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-FG4_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Fo1_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Fo1_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Fo2_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Fo2_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Fo3_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Fo3_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Fo4_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Fo4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Fo5_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Fo5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Fo6_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Fo6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Fo7_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Fo7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Fp1_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Fp1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Fp2_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Fp2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-IFJ1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-IFJ1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-IFJ2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-IFJ2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-IFS1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-IFS1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-IFS2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-IFS2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-IFS3_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-IFS3_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-IFS4_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-IFS4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Ia1_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Ia1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Ia2_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Ia2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Ia3_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Ia3_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Id10_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Id10_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Id1_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Id1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Id2_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Id2_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Id3_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Id3_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Id4_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Id4_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Id5_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Id5_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Id6_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Id6_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Id7_PM-v8.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Id7_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Id8_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Id8_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Id9_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Id9_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Ig1_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Ig1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Ig2_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Ig2_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Ig3_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Ig3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-MFG1_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-MFG1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-MFG2_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-MFG2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-OP1_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-OP1_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-OP2_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-OP2_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-OP3_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-OP3_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-OP4_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-OP4_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-OP5_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-OP5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-OP6_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-OP6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-OP7_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-OP7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-OP8_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-OP8_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-OP9_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-OP9_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-PF_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-PF_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-PFcm_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-PFcm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-PFm_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-PFm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-PFop_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-PFop_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-PFt_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-PFt_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-PGa_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-PGa_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-PGp_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-PGp_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Ph1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Ph1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Ph2_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Ph2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Ph3_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Ph3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-SFS1_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-SFS1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-SFS2_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-SFS2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-STS1_PM-v5.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-STS1_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-STS2_PM-v5.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-STS2_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-TE-1.0_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-TE-1.0_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-TE-1.1_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-TE-1.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-TE-1.2_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-TE-1.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-TE-2.1_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-TE-2.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-TE-2.2_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-TE-2.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-TE-3_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-TE-3_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-TI_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-TI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-TPJ_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-TPJ_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-TeI_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-TeI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hIP1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hIP1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hIP2_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hIP2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hIP3_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hIP3_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hIP4_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hIP4_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hIP5_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hIP5_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hIP6_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hIP6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hIP7_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hIP7_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hIP8_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hIP8_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hOc1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hOc1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hOc2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hOc2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hOc3d_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hOc3d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hOc3v_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hOc3v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hOc4d_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hOc4d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hOc4la_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hOc4la_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hOc4lp_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hOc4lp_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hOc4v_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hOc4v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hOc5_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hOc5_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hOc6_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hOc6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hPO1_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hPO1_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-p24ab.p24a_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-p24ab.p24a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-p24ab.p24b_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-p24ab.p24b_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-p24ab_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-p24ab_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-p24c.pd24cd_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-p24c.pd24cd_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-p24c.pd24cv_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-p24c.pd24cv_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-p24c.pv24c_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-p24c.pv24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-p24c_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-p24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-p32_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-p32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-s24.s24a_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-s24.s24a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-s24.s24b_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-s24.s24b_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-s24_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-s24_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-s32_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-s32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_BST_PM-v6.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_BST_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_CA1_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_CA1_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_CA2_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_CA2_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_CA3_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_CA3_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_CGL_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_CGL_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_CGM_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_CGM_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_CM.AAA_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_CM.AAA_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_CM.Ce_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_CM.Ce_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_CM.Me_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_CM.Me_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_CM_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_CM_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Ch-123_PM-v4.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Ch-123_PM-v4.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Ch-4_PM-v4.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Ch-4_PM-v4.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_DG_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_DG_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Dorsal-Dentate-Nucleus_PM-v6.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Dorsal-Dentate-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Entorhinal-Cortex_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Entorhinal-Cortex_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Fastigial-Nucleus_PM-v6.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Fastigial-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Frontal-II_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Frontal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Frontal-I_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Frontal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Frontal-to-Occipital_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Frontal-to-Occipital_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Frontal-to-Temporal-II_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Frontal-to-Temporal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Frontal-to-Temporal-I_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Frontal-to-Temporal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_FuCd_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_FuCd_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_FuP_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_FuP_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_HATA_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_HATA_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_HC-Transsubiculum_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_HC-Transsubiculum_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_IF.ice_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_IF.ice_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_IF.iol_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_IF.iol_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_IF.ld_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_IF.ld_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_IF_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_IF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Interposed-Nucleus_PM-v6.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Interposed-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_LB.Bl_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_LB.Bl_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_LB.Bm_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_LB.Bm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_LB.La_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_LB.La_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_LB.Pl_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_LB.Pl_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_LB_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_LB_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_MF.icm_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_MF.icm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_MF.lm_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_MF.lm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_MF_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_MF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_SF.AHi_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_SF.AHi_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_SF.APir_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_SF.APir_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_SF.VCo_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_SF.VCo_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_SF_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_SF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_STN_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_STN_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Subiculum.PaS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Subiculum.PaS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Subiculum.PreS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Subiculum.PreS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Subiculum.ProS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Subiculum.ProS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Subiculum.Sub_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Subiculum.Sub_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Temporal-to-Parietal_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Temporal-to-Parietal_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Terminal-islands_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Terminal-islands_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Tuberculum_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Tuberculum_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_VP_PM-v5.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_VP_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_VTM_PM-v8.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_VTM_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Ventral-Dentate-Nucleus_PM-v6.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Ventral-Dentate-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-1_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-1_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-25_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-25_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-2_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-33_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-33_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-3a_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-3a_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-3b_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-3b_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-44_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-44_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-45_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-45_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-4a_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-4a_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-4p_PM-v13.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-4p_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-5Ci_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-5Ci_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-5L_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-5L_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-5M_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-5M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-6d1_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-6d1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-6d2_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-6d2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-6d3_PM-v7.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-6d3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-6ma_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-6ma_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-6mp_PM-v12.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-6mp_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-7A_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-7A_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-7M_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-7M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-7PC_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-7PC_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-7P_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-7P_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-8d1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-8d1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-8d2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-8d2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-8v1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-8v1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-8v2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-8v2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-CoS1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-CoS1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-FG1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-FG1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-FG2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-FG2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-FG3_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-FG3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-FG4_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-FG4_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Fo1_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Fo1_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Fo2_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Fo2_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Fo3_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Fo3_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Fo4_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Fo4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Fo5_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Fo5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Fo6_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Fo6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Fo7_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Fo7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Fp1_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Fp1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Fp2_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Fp2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-IFJ1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-IFJ1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-IFJ2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-IFJ2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-IFS1_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-IFS1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-IFS2_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-IFS2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-IFS3_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-IFS3_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-IFS4_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-IFS4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Ia1_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Ia1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Ia2_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Ia2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Ia3_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Ia3_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Id10_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Id10_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Id1_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Id1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Id2_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Id2_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Id3_PM-v9.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Id3_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Id4_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Id4_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Id5_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Id5_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Id6_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Id6_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Id7_PM-v8.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Id7_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Id8_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Id8_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Id9_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Id9_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Ig1_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Ig1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Ig2_PM-v14.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Ig2_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Ig3_PM-v5.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Ig3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-MFG1_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-MFG1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-MFG2_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-MFG2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-OP1_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-OP1_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-OP2_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-OP2_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-OP3_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-OP3_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-OP4_PM-v12.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-OP4_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-OP5_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-OP5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-OP6_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-OP6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-OP7_PM-v3.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-OP7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-OP8_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-OP8_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-OP9_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-OP9_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-PF_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-PF_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-PFcm_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-PFcm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-PFm_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-PFm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-PFop_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-PFop_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-PFt_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-PFt_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-PGa_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-PGa_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-PGp_PM-v11.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-PGp_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Ph1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Ph1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Ph2_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Ph2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Ph3_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Ph3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-SFS1_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-SFS1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-SFS2_PM-v9.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-SFS2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-STS1_PM-v5.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-STS1_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-STS2_PM-v5.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-STS2_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-TE-1.0_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-TE-1.0_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-TE-1.1_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-TE-1.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-TE-1.2_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-TE-1.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-TE-2.1_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-TE-2.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-TE-2.2_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-TE-2.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-TE-3_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-TE-3_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-TI_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-TI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-TPJ_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-TPJ_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-TeI_PM-v6.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-TeI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hIP1_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hIP1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hIP2_PM-v7.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hIP2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hIP3_PM-v9.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hIP3_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hIP4_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hIP4_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hIP5_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hIP5_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hIP6_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hIP6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hIP7_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hIP7_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hIP8_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hIP8_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hOc1_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hOc1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hOc2_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hOc2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hOc3d_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hOc3d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hOc3v_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hOc3v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hOc4d_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hOc4d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hOc4la_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hOc4la_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hOc4lp_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hOc4lp_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hOc4v_PM-v5.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hOc4v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hOc5_PM-v4.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hOc5_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hOc6_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hOc6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hPO1_PM-v7.3.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hPO1_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-p24ab_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-p24ab_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-p24c_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-p24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-p32_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-p32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-s24_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-s24_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-s32_PM-v20.1.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-s32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_CA1_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_CA1_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_CA2_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_CA2_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_CA3_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_CA3_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_CGL_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_CGL_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_CGM_PM-v10.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_CGM_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_DG_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_DG_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Entorhinal-Cortex_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Entorhinal-Cortex_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Frontal-II_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Frontal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Frontal-I_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Frontal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Frontal-to-Occipital_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Frontal-to-Occipital_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Frontal-to-Temporal-II_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Frontal-to-Temporal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Frontal-to-Temporal-I_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Frontal-to-Temporal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_HATA_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_HATA_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_HC-Transsubiculum_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_HC-Transsubiculum_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Subiculum.PaS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Subiculum.PaS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Subiculum.PreS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Subiculum.PreS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Subiculum.ProS_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Subiculum.ProS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Subiculum.Sub_PM-v13.2.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Subiculum.Sub_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Temporal-to-Parietal_PM-v11.4.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Temporal-to-Parietal_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Tuberculum_PM-v4.0.jsonld
+++ b/instances/latest/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Tuberculum_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_agranularInsularCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_agranularInsularCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_amygdalopiriformTransitionArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_amygdalopiriformTransitionArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_anteriorIntraparietalAreaOfCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_anteriorIntraparietalAreaOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area10OfCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area10OfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area11OfCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area11OfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area13OfCortexLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area13OfCortexLateralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area13OfCortexMedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area13OfCortexMedialPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area13aOfCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area13aOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area13bOfCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area13bOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area14OfCortexCaudalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area14OfCortexCaudalPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area14OfCortexRostralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area14OfCortexRostralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area19OfCortexDorsointermediatePart.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area19OfCortexDorsointermediatePart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area19OfCortexMedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area19OfCortexMedialPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area23OfCortexVentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area23OfCortexVentralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area23aOfCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area23aOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area23bOfCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area23bOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area23cOfCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area23cOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area24aOfCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area24aOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area24bOfCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area24bOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area24cOfCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area24cOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area24dOfCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area24dOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area25OfCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area25OfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area29a-cOfCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area29a-cOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area29dOfCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area29dOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area30OfCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area30OfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area31OfCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area31OfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area32OfCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area32OfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area32OfCortexVentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area32OfCortexVentralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area35OfCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area35OfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area36OfCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area36OfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area3aOfCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area3aOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area3bOfCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area3bOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area45OfCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area45OfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area46OfCortexDorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area46OfCortexDorsalPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area46OfCortexVentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area46OfCortexVentralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area47OfCortexLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area47OfCortexLateralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area47OfCortexMedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area47OfCortexMedialPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area47OfCortexOrbitalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area47OfCortexOrbitalPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area4OfCortexPartC.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area4OfCortexPartC.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area4OfCortexPartsAAndB.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area4OfCortexPartsAAndB.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area6OfCortexDorsocaudalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area6OfCortexDorsocaudalPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area6OfCortexDorsorostralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area6OfCortexDorsorostralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area6OfCortexMedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area6OfCortexMedialPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area6OfCortexVentralPartA.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area6OfCortexVentralPartA.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area6OfCortexVentralPartB.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area6OfCortexVentralPartB.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area8OfCortexCaudalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area8OfCortexCaudalPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area8aOfCortexDorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area8aOfCortexDorsalPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area8aOfCortexVentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area8aOfCortexVentralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area8bOfCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area8bOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area9OfCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area9OfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_areas1And2OfCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_areas1And2OfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexAnterolateralArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexAnterolateralArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexCaudalParabeltArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexCaudalParabeltArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexCaudolateralArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexCaudolateralArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexCaudomedialArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexCaudomedialArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexMiddleLateralArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexMiddleLateralArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexPrimaryArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexPrimaryArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexRostralArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexRostralArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexRostralParabelt.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexRostralParabelt.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexRostromedialArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexRostromedialArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexRostrotemporal.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexRostrotemporal.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexRostrotemporalLateralArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexRostrotemporalLateralArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexRostrotemporalMedialArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexRostrotemporalMedialArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_dysgranularInsularCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_dysgranularInsularCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_entorhinalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_entorhinalCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_fundusOfSuperiorTemporalSulcusAreaOfCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_fundusOfSuperiorTemporalSulcusAreaOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_granularInsularCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_granularInsularCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_gustatoryCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_gustatoryCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_insularProisocortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_insularProisocortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_lateralIntraparietalAreaOfCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_lateralIntraparietalAreaOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_medialIntraparietalAreaOfCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_medialIntraparietalAreaOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_medialSuperiorTemporalAreaOfCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_medialSuperiorTemporalAreaOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_occipito-parietalTransitionalAreaOfCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_occipito-parietalTransitionalAreaOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_orbitalPeriallocortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_orbitalPeriallocortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_orbitalProisocortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_orbitalProisocortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parainsularCortexLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parainsularCortexLateralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parainsularCortexMedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parainsularCortexMedialPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreaPE.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreaPE.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreaPECaudalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreaPECaudalPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreaPF.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreaPF.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreaPFG.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreaPFG.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreaPG.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreaPG.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreaPGMedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreaPGMedialPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreasPGaAndIPa.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreasPGaAndIPa.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_piriformCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_piriformCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_primaryVisualCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_primaryVisualCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_proisocorticalMotorRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_proisocorticalMotorRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_prostriateArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_prostriateArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_retroinsularArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_retroinsularArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_secondarySomatosensoryCortexExternalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_secondarySomatosensoryCortexExternalPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_secondarySomatosensoryCortexInternalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_secondarySomatosensoryCortexInternalPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_secondarySomatosensoryCortexParietalRostralArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_secondarySomatosensoryCortexParietalRostralArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_secondarySomatosensoryCortexParietalVentralArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_secondarySomatosensoryCortexParietalVentralArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_superiorTemporalRostralArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_superiorTemporalRostralArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTE1.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTE1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTE2.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTE2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTE3.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTE3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTEOccipitalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTEOccipitalPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTF.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTF.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTFOccipitalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTFOccipitalPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTH.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTH.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTL.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTL.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTLOccipitalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTLOccipitalPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalProisocortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalProisocortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporo-parieto-occipitalAssociationArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporo-parieto-occipitalAssociationArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporoparietalTransitionalArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporoparietalTransitionalArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporopolarProisocortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporopolarProisocortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_ventralIntraparietalAreaOfCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_ventralIntraparietalAreaOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea2.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea3.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea3A.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea3A.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea4.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea4TransitionalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea4TransitionalPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea5.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea6.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea6.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea6A.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea6A.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_alveusOfTheHippocampus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_alveusOfTheHippocampus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_anteriorCommissureAnteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_anteriorCommissureAnteriorPart.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_anteriorCommissureIntrabulbarPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_anteriorCommissureIntrabulbarPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_anteriorCommissurePosteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_anteriorCommissurePosteriorPart.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_ascendingFibersOfTheFacialNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_ascendingFibersOfTheFacialNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_basalForebrainRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_basalForebrainRegion.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_bedNucleusOfTheStriaTerminalis.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_bedNucleusOfTheStriaTerminalis.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_brachiumOfTheSuperiorColliculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_brachiumOfTheSuperiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_brainstem.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_brainstem.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_caudalEntorhinalField.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_caudalEntorhinalField.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_centralCanal.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_centralCanal.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_cingulateCortexArea2.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_cingulateCortexArea2.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_commissuralStriaTerminalis.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_commissuralStriaTerminalis.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_commissureOfTheInferiorColliculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_commissureOfTheInferiorColliculus.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_commissureOfTheSuperiorColliculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_commissureOfTheSuperiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_corpusCallosumAndAssociatedSubcorticalWhiteMatter.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_corpusCallosumAndAssociatedSubcorticalWhiteMatter.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_deeperCerebellum.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_deeperCerebellum.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_deeperLayersOfTheSuperiorColliculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_deeperLayersOfTheSuperiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_descendingCorticofugalPathways.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_descendingCorticofugalPathways.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_dorsalintermediateEntorhinalArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_dorsalintermediateEntorhinalArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_dorsallateralEntorhinalArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_dorsallateralEntorhinalArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_entopeduncularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_entopeduncularNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_facialNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_facialNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_fasciculusRetroflexus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_fasciculusRetroflexus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_fimbriaOfTheHippocampus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_fimbriaOfTheHippocampus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_fornix.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_fornix.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_frontalAssociationCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_frontalAssociationCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_genuOfTheFacialNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_genuOfTheFacialNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_globusPallidus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_globusPallidus.jsonld
@@ -15,7 +15,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_glomerularLayerOfTheAccessoryOlfactoryBulb.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_glomerularLayerOfTheAccessoryOlfactoryBulb.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_glomerularLayerOfTheOlfactoryBulb.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_glomerularLayerOfTheOlfactoryBulb.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_habenularCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_habenularCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_hippocampalFormation.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_hippocampalFormation.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_hypothalamicRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_hypothalamicRegion.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_inferiorCerebellarPeduncle.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_inferiorCerebellarPeduncle.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_inferiorColliculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_inferiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_inferiorOlive.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_inferiorOlive.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_innerEar.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_innerEar.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_interpeduncularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_interpeduncularNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_mammillothalamicTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_mammillothalamicTract.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_medialEntorhinalField.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_medialEntorhinalField.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_medialLemniscus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_medialLemniscus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_medialLemniscusDecussation.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_medialLemniscusDecussation.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_middleCerebellarPeduncle.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_middleCerebellarPeduncle.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_molecularCellLayerOfTheCerebellum.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_molecularCellLayerOfTheCerebellum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_neocortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_neocortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_nucleusOfTheStriaMedullaris.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_nucleusOfTheStriaMedullaris.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_olfactoryBulb.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_olfactoryBulb.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_opticNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_opticNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_opticTractAndOpticChiasm.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_opticTractAndOpticChiasm.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_periaqueductalGray.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_periaqueductalGray.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_perirhinalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_perirhinalCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_periventricularGray.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_periventricularGray.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_pinealGland.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_pinealGland.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_pontineNuclei.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_pontineNuclei.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_posteriorCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_posteriorCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_postrhinalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_postrhinalCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_pretectalRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_pretectalRegion.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_pyramidalDecussation.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_pyramidalDecussation.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_septalRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_septalRegion.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_spinalCord.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_spinalCord.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_spinalTrigeminalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_spinalTrigeminalNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_spinalTrigeminalTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_spinalTrigeminalTract.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_striaMedullarisOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_striaMedullarisOfTheThalamus.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_striaTerminalis.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_striaTerminalis.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_striatum.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_striatum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_subiculum.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_subiculum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_substantiaNigra.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_substantiaNigra.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_subthalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_subthalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_superficialGrayLayerOfTheSuperiorColliculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_superficialGrayLayerOfTheSuperiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_supraopticDecussation.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_supraopticDecussation.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_thalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_thalamus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_transverseFibersOfThePons.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_transverseFibersOfThePons.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_ventralHippocampalCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_ventralHippocampalCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_ventralintermediateEntorhinalArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_ventralintermediateEntorhinalArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_ventricularSystem.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_ventricularSystem.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_alveusOfTheHippocampus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_alveusOfTheHippocampus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_anteriorCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_anteriorCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_anteriorCommissureAnteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_anteriorCommissureAnteriorPart.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_anteriorCommissurePosteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_anteriorCommissurePosteriorPart.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_ascendingFibersOfTheFacialNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_ascendingFibersOfTheFacialNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_basalForebrainRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_basalForebrainRegion.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_bedNucleusOfTheStriaTerminalis.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_bedNucleusOfTheStriaTerminalis.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_brachiumOfTheSuperiorColliculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_brachiumOfTheSuperiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_brainstem.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_brainstem.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_centralCanal.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_centralCanal.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_cingulateCortexArea2.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_cingulateCortexArea2.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_commissuralStriaTerminalis.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_commissuralStriaTerminalis.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_commissureOfTheInferiorColliculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_commissureOfTheInferiorColliculus.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_commissureOfTheSuperiorColliculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_commissureOfTheSuperiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_cornuAmmonis1.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_cornuAmmonis1.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_cornuAmmonis2.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_cornuAmmonis2.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_cornuAmmonis3.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_cornuAmmonis3.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_corpusCallosumAndAssociatedSubcorticalWhiteMatter.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_corpusCallosumAndAssociatedSubcorticalWhiteMatter.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_deeperLayersOfTheSuperiorColliculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_deeperLayersOfTheSuperiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_dentateGyrus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_dentateGyrus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_descendingCorticofugalPathways.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_descendingCorticofugalPathways.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_entopeduncularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_entopeduncularNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_entorhinalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_entorhinalCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_facialNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_facialNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_fasciculusRetroflexus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_fasciculusRetroflexus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_fasciolaCinereum.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_fasciolaCinereum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_fimbriaOfTheHippocampus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_fimbriaOfTheHippocampus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_fornix.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_fornix.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_frontalAssociationCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_frontalAssociationCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_genuOfTheFacialNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_genuOfTheFacialNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_globusPallidus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_globusPallidus.jsonld
@@ -15,7 +15,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_glomerularLayerOfTheAccessoryOlfactoryBulb.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_glomerularLayerOfTheAccessoryOlfactoryBulb.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_glomerularLayerOfTheOlfactoryBulb.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_glomerularLayerOfTheOlfactoryBulb.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_granuleCellLevelOfTheCerebellum.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_granuleCellLevelOfTheCerebellum.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_habenularCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_habenularCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_hypothalamicRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_hypothalamicRegion.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_inferiorCerebellarPeduncle.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_inferiorCerebellarPeduncle.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_inferiorColliculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_inferiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_inferiorOlive.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_inferiorOlive.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_innerEar.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_innerEar.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_interpeduncularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_interpeduncularNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_lateralEntorhinalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_lateralEntorhinalCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_mammillothalamicTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_mammillothalamicTract.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_medialLemniscus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_medialLemniscus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_medialLemniscusDecussation.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_medialLemniscusDecussation.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_middleCerebellarPeduncle.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_middleCerebellarPeduncle.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_molecularLayerOfTheCerebellum.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_molecularLayerOfTheCerebellum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_neocortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_neocortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_nucleusOfTheStriaMedullaris.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_nucleusOfTheStriaMedullaris.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_olfactoryBulb.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_olfactoryBulb.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_opticNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_opticNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_opticTractAndOpticChiasm.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_opticTractAndOpticChiasm.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_parasubiculum.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_parasubiculum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_periaqueductalGray.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_periaqueductalGray.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_perirhinalArea35.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_perirhinalArea35.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_perirhinalArea36.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_perirhinalArea36.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_periventricularGray.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_periventricularGray.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_pinealGland.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_pinealGland.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_pontineNuclei.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_pontineNuclei.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_posteriorCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_posteriorCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_postrhinalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_postrhinalCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_presubiculum.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_presubiculum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_pretectalRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_pretectalRegion.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_pyramidalDecussation.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_pyramidalDecussation.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_septalRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_septalRegion.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_spinalCord.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_spinalCord.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_spinalTrigeminalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_spinalTrigeminalNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_spinalTrigeminalTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_spinalTrigeminalTract.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_striaMedullarisOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_striaMedullarisOfTheThalamus.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_striaTerminalis.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_striaTerminalis.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_striatum.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_striatum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_subiculum.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_subiculum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_substantiaNigra.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_substantiaNigra.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_subthalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_subthalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_superficialGrayLayerOfTheSuperiorColliculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_superficialGrayLayerOfTheSuperiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_supraopticDecussation.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_supraopticDecussation.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_thalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_thalamus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_transverseFibersOfThePons.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_transverseFibersOfThePons.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_ventralHippocampalCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_ventralHippocampalCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_ventricularSystem.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_ventricularSystem.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_4thVentricle.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_4thVentricle.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_acousticStriae.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_acousticStriae.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_alveusOfTheHippocampus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_alveusOfTheHippocampus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_anteriorCommissureAnteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_anteriorCommissureAnteriorPart.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_anteriorCommissureIntrabulbarPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_anteriorCommissureIntrabulbarPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_anteriorCommissurePosteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_anteriorCommissurePosteriorPart.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_ascendingFibersOfTheFacialNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_ascendingFibersOfTheFacialNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_auditoryRadiation.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_auditoryRadiation.jsonld
@@ -15,7 +15,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_basalForebrainRegionUnspecified.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_basalForebrainRegionUnspecified.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_bedNucleusOfTheStriaTerminalis.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_bedNucleusOfTheStriaTerminalis.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_brachiumOfTheSuperiorColliculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_brachiumOfTheSuperiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_brainstemUnspecified.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_brainstemUnspecified.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_centralCanal.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_centralCanal.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_cingulateCortexArea2.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_cingulateCortexArea2.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_cochlea.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_cochlea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_cochlearNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_cochlearNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_commissuralStriaTerminalis.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_commissuralStriaTerminalis.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_commissureOfTheSuperiorColliculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_commissureOfTheSuperiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_cornuAmmonis1.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_cornuAmmonis1.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_cornuAmmonis2.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_cornuAmmonis2.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_cornuAmmonis3.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_cornuAmmonis3.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_corpusCallosumAndAssociatedSubcorticalWhiteMatter.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_corpusCallosumAndAssociatedSubcorticalWhiteMatter.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_deeperCerebellum.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_deeperCerebellum.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_deeperLayersOfTheSuperiorColliculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_deeperLayersOfTheSuperiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_dentateGyrus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_dentateGyrus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_descendingCorticofugalPathways.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_descendingCorticofugalPathways.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_dorsalCochlearNucleusDeepCore.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_dorsalCochlearNucleusDeepCore.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_dorsalCochlearNucleusFusiformAndGranuleLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_dorsalCochlearNucleusFusiformAndGranuleLayer.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_dorsalCochlearNucleusMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_dorsalCochlearNucleusMolecularLayer.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_entopeduncularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_entopeduncularNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_facialNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_facialNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_fasciculusRetroflexus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_fasciculusRetroflexus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_fasciolaCinereum.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_fasciolaCinereum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_fimbriaOfTheHippocampus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_fimbriaOfTheHippocampus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_fornix.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_fornix.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_frontalAssociationCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_frontalAssociationCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_genuOfTheFacialNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_genuOfTheFacialNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_globusPallidus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_globusPallidus.jsonld
@@ -15,7 +15,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_glomerularLayerOfTheAccessoryOlfactoryBulb.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_glomerularLayerOfTheAccessoryOlfactoryBulb.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_glomerularLayerOfTheOlfactoryBulb.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_glomerularLayerOfTheOlfactoryBulb.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_habenularCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_habenularCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_hypothalamicRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_hypothalamicRegion.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_inferiorCerebellarPeduncle.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_inferiorCerebellarPeduncle.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_inferiorColliculusBrachium.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_inferiorColliculusBrachium.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_inferiorColliculusCentralNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_inferiorColliculusCentralNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_inferiorColliculusCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_inferiorColliculusCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_inferiorColliculusDorsalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_inferiorColliculusDorsalCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_inferiorColliculusExternalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_inferiorColliculusExternalCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_inferiorOlive.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_inferiorOlive.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_interpeduncularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_interpeduncularNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_lateralEntorhinalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_lateralEntorhinalCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_lateralLemniscus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_lateralLemniscus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_lateralLemniscusCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_lateralLemniscusCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_lateralLemniscusDorsalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_lateralLemniscusDorsalNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_lateralLemniscusIntermediateNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_lateralLemniscusIntermediateNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_lateralLemniscusVentralNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_lateralLemniscusVentralNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_lateralSuperiorOlive.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_lateralSuperiorOlive.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_mammillotegmentalTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_mammillotegmentalTract.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_medialEntorhinalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_medialEntorhinalCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_medialGeniculateBodyDorsalDivision.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_medialGeniculateBodyDorsalDivision.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_medialGeniculateBodyMarginalZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_medialGeniculateBodyMarginalZone.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_medialGeniculateBodyMedialDivision.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_medialGeniculateBodyMedialDivision.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_medialGeniculateBodyVentralDivision.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_medialGeniculateBodyVentralDivision.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_medialLemniscus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_medialLemniscus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_medialLemniscusDecussation.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_medialLemniscusDecussation.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_medialSuperiorOlive.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_medialSuperiorOlive.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_middleCerebellarPeduncle.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_middleCerebellarPeduncle.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_molecularCellLayerOfTheCerebellum.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_molecularCellLayerOfTheCerebellum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_neocortexUnspecified.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_neocortexUnspecified.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_nucleusOfTheStriaMedullaris.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_nucleusOfTheStriaMedullaris.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_nucleusOfTheTrapezoidBody.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_nucleusOfTheTrapezoidBody.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_nucleusSagulum.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_nucleusSagulum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_olfactoryBulb.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_olfactoryBulb.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_opticNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_opticNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_opticTractAndOpticChiasm.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_opticTractAndOpticChiasm.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_parasubiculum.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_parasubiculum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_periaqueductalGray.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_periaqueductalGray.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_perirhinalArea35.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_perirhinalArea35.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_perirhinalArea36.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_perirhinalArea36.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_periventricularGray.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_periventricularGray.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_pinealGland.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_pinealGland.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_pontineNuclei.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_pontineNuclei.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_posteriorCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_posteriorCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_postrhinalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_postrhinalCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_presubiculum.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_presubiculum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_pretectalRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_pretectalRegion.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_primaryAuditoryCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_primaryAuditoryCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_pyramidalDecussation.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_pyramidalDecussation.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_reticularThalamicNucleusAuditorySegment.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_reticularThalamicNucleusAuditorySegment.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_secondaryAuditoryCortexDorsalArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_secondaryAuditoryCortexDorsalArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_secondaryAuditoryCortexVentralArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_secondaryAuditoryCortexVentralArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_septalRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_septalRegion.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_spinalCord.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_spinalCord.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_spinalTrigeminalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_spinalTrigeminalNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_spinalTrigeminalTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_spinalTrigeminalTract.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_spiralGanglion.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_spiralGanglion.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_striaMedullarisOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_striaMedullarisOfTheThalamus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_striaTerminalis.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_striaTerminalis.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_striatum.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_striatum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_subiculum.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_subiculum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_substantiaNigra.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_substantiaNigra.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_subthalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_subthalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_superficialGrayLayerOfTheSuperiorColliculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_superficialGrayLayerOfTheSuperiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_superiorParaolivaryNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_superiorParaolivaryNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_superiorPeriolivaryRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_superiorPeriolivaryRegion.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_supraopticDecussation.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_supraopticDecussation.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_thalamusUnspecified.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_thalamusUnspecified.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_transverseFibersOfThePons.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_transverseFibersOfThePons.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_trapezoidBody.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_trapezoidBody.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_ventralCochlearNucleusAnteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_ventralCochlearNucleusAnteriorPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_ventralCochlearNucleusCapArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_ventralCochlearNucleusCapArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_ventralCochlearNucleusGranuleCellLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_ventralCochlearNucleusGranuleCellLayer.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_ventralCochlearNucleusPosteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_ventralCochlearNucleusPosteriorPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_ventralHippocampalCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_ventralHippocampalCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_ventralPeriolivaryNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_ventralPeriolivaryNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_ventricularSystemUnspecified.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_ventricularSystemUnspecified.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_vestibularApparatus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_vestibularApparatus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_vestibularNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_vestibularNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_4thVentricle.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_4thVentricle.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_acousticStriae.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_acousticStriae.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_alveusOfTheHippocampus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_alveusOfTheHippocampus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_anteriorCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_anteriorCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_anteriorCommissureAnteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_anteriorCommissureAnteriorPart.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_anteriorCommissurePosteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_anteriorCommissurePosteriorPart.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_ascendingFibersOfTheFacialNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_ascendingFibersOfTheFacialNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_auditoryRadiation.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_auditoryRadiation.jsonld
@@ -15,7 +15,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_basalForebrainRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_basalForebrainRegion.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_bedNucleusOfTheStriaTerminalis.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_bedNucleusOfTheStriaTerminalis.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_brachiumOfTheSuperiorColliculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_brachiumOfTheSuperiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_brainstem.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_brainstem.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_centralCanal.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_centralCanal.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_cingulateCortexArea2.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_cingulateCortexArea2.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_cochlea.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_cochlea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_cochlearNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_cochlearNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_commissuralStriaTerminalis.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_commissuralStriaTerminalis.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_commissureOfTheSuperiorColliculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_commissureOfTheSuperiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_cornuAmmonis1.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_cornuAmmonis1.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_cornuAmmonis2.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_cornuAmmonis2.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_cornuAmmonis3.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_cornuAmmonis3.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_corpusCallosumAndAssociatedSubcorticalWhiteMatter.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_corpusCallosumAndAssociatedSubcorticalWhiteMatter.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_deeperLayersOfTheSuperiorColliculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_deeperLayersOfTheSuperiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_dentateGyrus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_dentateGyrus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_descendingCorticofugalPathways.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_descendingCorticofugalPathways.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_dorsalCochlearNucleusDeepCore.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_dorsalCochlearNucleusDeepCore.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_dorsalCochlearNucleusFusiformAndGranuleLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_dorsalCochlearNucleusFusiformAndGranuleLayer.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_dorsalCochlearNucleusMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_dorsalCochlearNucleusMolecularLayer.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_entopeduncularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_entopeduncularNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_entorhinalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_entorhinalCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_facialNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_facialNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_fasciculusRetroflexus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_fasciculusRetroflexus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_fasciolaCinereum.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_fasciolaCinereum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_fimbriaOfTheHippocampus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_fimbriaOfTheHippocampus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_fornix.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_fornix.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_frontalAssociationCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_frontalAssociationCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_genuOfTheFacialNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_genuOfTheFacialNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_globusPallidus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_globusPallidus.jsonld
@@ -15,7 +15,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_glomerularLayerOfTheAccessoryOlfactoryBulb.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_glomerularLayerOfTheAccessoryOlfactoryBulb.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_glomerularLayerOfTheOlfactoryBulb.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_glomerularLayerOfTheOlfactoryBulb.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_granuleCellLevelOfTheCerebellum.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_granuleCellLevelOfTheCerebellum.jsonld
@@ -15,7 +15,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_habenularCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_habenularCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_hypothalamicRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_hypothalamicRegion.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_inferiorCerebellarPeduncle.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_inferiorCerebellarPeduncle.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_inferiorColliculusBrachium.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_inferiorColliculusBrachium.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_inferiorColliculusCentralNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_inferiorColliculusCentralNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_inferiorColliculusCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_inferiorColliculusCommissure.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_inferiorColliculusDorsalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_inferiorColliculusDorsalCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_inferiorColliculusExternalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_inferiorColliculusExternalCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_inferiorOlive.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_inferiorOlive.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_interpeduncularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_interpeduncularNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_lateralEntorhinalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_lateralEntorhinalCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_lateralLemniscus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_lateralLemniscus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_lateralLemniscusCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_lateralLemniscusCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_lateralLemniscusDorsalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_lateralLemniscusDorsalNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_lateralLemniscusIntermediateNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_lateralLemniscusIntermediateNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_lateralLemniscusVentralNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_lateralLemniscusVentralNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_lateralSuperiorOlive.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_lateralSuperiorOlive.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_mammillothalamicTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_mammillothalamicTract.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_medialGeniculateBodyDorsalDivision.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_medialGeniculateBodyDorsalDivision.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_medialGeniculateBodyMarginalZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_medialGeniculateBodyMarginalZone.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_medialGeniculateBodyMedialDivision.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_medialGeniculateBodyMedialDivision.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_medialGeniculateBodyVentralDivision.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_medialGeniculateBodyVentralDivision.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_medialLemniscus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_medialLemniscus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_medialLemniscusDecussation.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_medialLemniscusDecussation.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_medialSuperiorOlive.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_medialSuperiorOlive.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_middleCerebellarPeduncle.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_middleCerebellarPeduncle.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_molecularLayerOfTheCerebellum.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_molecularLayerOfTheCerebellum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_neocortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_neocortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_nucleusOfTheStriaMedullaris.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_nucleusOfTheStriaMedullaris.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_nucleusOfTheTrapezoidBody.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_nucleusOfTheTrapezoidBody.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_nucleusSagulum.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_nucleusSagulum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_olfactoryBulb.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_olfactoryBulb.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_opticNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_opticNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_opticTractAndOpticChiasm.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_opticTractAndOpticChiasm.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_parasubiculum.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_parasubiculum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_periaqueductalGray.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_periaqueductalGray.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_perirhinalArea35.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_perirhinalArea35.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_perirhinalArea36.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_perirhinalArea36.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_periventricularGray.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_periventricularGray.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_pinealGland.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_pinealGland.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_pontineNuclei.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_pontineNuclei.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_posteriorCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_posteriorCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_postrhinalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_postrhinalCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_presubiculum.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_presubiculum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_pretectalRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_pretectalRegion.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_primaryAuditoryCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_primaryAuditoryCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_pyramidalDecussation.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_pyramidalDecussation.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_reticularThalamicNucleusAuditorySegment.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_reticularThalamicNucleusAuditorySegment.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_secondaryAuditoryCortexDorsalArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_secondaryAuditoryCortexDorsalArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_secondaryAuditoryCortexVentralArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_secondaryAuditoryCortexVentralArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_septalRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_septalRegion.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_spinalCord.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_spinalCord.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_spinalTrigeminalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_spinalTrigeminalNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_spinalTrigeminalTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_spinalTrigeminalTract.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_spiralGanglion.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_spiralGanglion.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_striaMedullarisOfTheThalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_striaMedullarisOfTheThalamus.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_striaTerminalis.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_striaTerminalis.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_striatum.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_striatum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_subiculum.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_subiculum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_substantiaNigra.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_substantiaNigra.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_subthalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_subthalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_superficialGrayLayerOfTheSuperiorColliculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_superficialGrayLayerOfTheSuperiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_superiorParaolivaryNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_superiorParaolivaryNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_superiorPeriolivaryRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_superiorPeriolivaryRegion.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_supraopticDecussation.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_supraopticDecussation.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_thalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_thalamus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_transverseFibersOfThePons.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_transverseFibersOfThePons.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_trapezoidBody.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_trapezoidBody.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_ventralCochlearNucleusAnteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_ventralCochlearNucleusAnteriorPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_ventralCochlearNucleusCapArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_ventralCochlearNucleusCapArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_ventralCochlearNucleusGranuleCellLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_ventralCochlearNucleusGranuleCellLayer.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_ventralCochlearNucleusPosteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_ventralCochlearNucleusPosteriorPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_ventralHippocampalCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_ventralHippocampalCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_ventralPeriolivaryNuclei.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_ventralPeriolivaryNuclei.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_ventricularSystem.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_ventricularSystem.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_vestibularApparatus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_vestibularApparatus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_vestibularNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_vestibularNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_4thVentricle.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_4thVentricle.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_acousticStriae.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_acousticStriae.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_agranularInsularCortexDorsalArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_agranularInsularCortexDorsalArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_agranularInsularCortexPosteriorArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_agranularInsularCortexPosteriorArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_agranularInsularCortexVentralArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_agranularInsularCortexVentralArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_alveusOfTheHippocampus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_alveusOfTheHippocampus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_amygdaloidAreaUnspecified.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_amygdaloidAreaUnspecified.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_angularThalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_angularThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_anteriorCommissureAnteriorLimb.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_anteriorCommissureAnteriorLimb.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_anteriorCommissureIntrabulbarPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_anteriorCommissureIntrabulbarPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_anteriorCommissurePosteriorLimb.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_anteriorCommissurePosteriorLimb.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_anterodorsalThalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_anterodorsalThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_anteromedialThalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_anteromedialThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_anteroventralThalamicNucleusDorsomedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_anteroventralThalamicNucleusDorsomedialPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_anteroventralThalamicNucleusVentrolateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_anteroventralThalamicNucleusVentrolateralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ascendingFibersOfTheFacialNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ascendingFibersOfTheFacialNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_basalForebrainRegionUnspecified.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_basalForebrainRegionUnspecified.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_bedNucleusOfTheStriaTerminalis.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_bedNucleusOfTheStriaTerminalis.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_brachiumOfTheSuperiorColliculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_brachiumOfTheSuperiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_brainstemUnspecified.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_brainstemUnspecified.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_caudatePutamen.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_caudatePutamen.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_centralCanal.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_centralCanal.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_centralLateralThalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_centralLateralThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_centralMedialThalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_centralMedialThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_cerebellumUnspecified.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_cerebellumUnspecified.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_cingulateArea1.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_cingulateArea1.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_cingulateArea2.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_cingulateArea2.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_claustrum.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_claustrum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_cochlea.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_cochlea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_cochlearNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_cochlearNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_commissuralStriaTerminalis.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_commissuralStriaTerminalis.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_commissureOfTheSuperiorColliculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_commissureOfTheSuperiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_cornuAmmonis1.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_cornuAmmonis1.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_cornuAmmonis2.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_cornuAmmonis2.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_cornuAmmonis3.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_cornuAmmonis3.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_corpusCallosumAndAssociatedSubcorticalWhiteMatter.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_corpusCallosumAndAssociatedSubcorticalWhiteMatter.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_corticofugalTractAndCoronaRadiata.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_corticofugalTractAndCoronaRadiata.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_deeperLayersOfTheSuperiorColliculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_deeperLayersOfTheSuperiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_dentateGyrus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_dentateGyrus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_dorsalCochlearNucleusDeepCore.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_dorsalCochlearNucleusDeepCore.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_dorsalCochlearNucleusFusiformAndGranuleLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_dorsalCochlearNucleusFusiformAndGranuleLayer.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_dorsalCochlearNucleusMolecularLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_dorsalCochlearNucleusMolecularLayer.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_dorsalLateralGeniculateNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_dorsalLateralGeniculateNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_dorsolateralOrbitalArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_dorsolateralOrbitalArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_dysgranularInsularCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_dysgranularInsularCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_endopiriformNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_endopiriformNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_entopeduncularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_entopeduncularNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ethmoidLimitansNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ethmoidLimitansNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_externalMedullaryLaminaAuditoryRadiation.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_externalMedullaryLaminaAuditoryRadiation.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_externalMedullaryLaminaUnspecified.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_externalMedullaryLaminaUnspecified.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_facialNerveUnspecified.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_facialNerveUnspecified.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_fasciculusRetroflexus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_fasciculusRetroflexus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_fasciolaCinereum.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_fasciolaCinereum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_fieldsOfForel.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_fieldsOfForel.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_fimbriaOfTheHippocampus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_fimbriaOfTheHippocampus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_fornix.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_fornix.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_frontalAssociationArea3.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_frontalAssociationArea3.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_frontalAssociationCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_frontalAssociationCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_genuOfTheFacialNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_genuOfTheFacialNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_globusPallidusExternalLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_globusPallidusExternalLateralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_globusPallidusExternalMedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_globusPallidusExternalMedialPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_glomerularLayerOfTheAccessoryOlfactoryBulb.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_glomerularLayerOfTheAccessoryOlfactoryBulb.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_glomerularLayerOfTheOlfactoryBulb.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_glomerularLayerOfTheOlfactoryBulb.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_granularInsularCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_granularInsularCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_habenularCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_habenularCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_hypothalamicRegionUnspecified.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_hypothalamicRegionUnspecified.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_inferiorCerebellarPeduncle.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_inferiorCerebellarPeduncle.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_inferiorColliculusBrachium.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_inferiorColliculusBrachium.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_inferiorColliculusCentralNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_inferiorColliculusCentralNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_inferiorColliculusCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_inferiorColliculusCommissure.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_inferiorColliculusDorsalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_inferiorColliculusDorsalCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_inferiorColliculusExternalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_inferiorColliculusExternalCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_inferiorOlive.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_inferiorOlive.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_infralimbicArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_infralimbicArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_interanteromedialThalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_interanteromedialThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_intergeniculateLeaflet.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_intergeniculateLeaflet.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_intermediodorsalThalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_intermediodorsalThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_internalMedullaryLamina.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_internalMedullaryLamina.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_interpeduncularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_interpeduncularNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_intramedullaryThalamicArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_intramedullaryThalamicArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralEntorhinalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralEntorhinalCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralHabenularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralHabenularNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralLemniscusCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralLemniscusCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralLemniscusDorsalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralLemniscusDorsalNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralLemniscusIntermediateNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralLemniscusIntermediateNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralLemniscusUnspecified.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralLemniscusUnspecified.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralLemniscusVentralNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralLemniscusVentralNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralOlfactoryTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralOlfactoryTract.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralOrbitalArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralOrbitalArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralPosteriorThalamicNucleusLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralPosteriorThalamicNucleusLateralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralPosteriorThalamicNucleusMediocaudalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralPosteriorThalamicNucleusMediocaudalPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralPosteriorThalamicNucleusMediorostralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralPosteriorThalamicNucleusMediorostralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralSuperiorOlive.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralSuperiorOlive.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_laterodorsalThalamicNucleusDorsomedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_laterodorsalThalamicNucleusDorsomedialPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_laterodorsalThalamicNucleusVentrolateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_laterodorsalThalamicNucleusVentrolateralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_mammillotegmentalTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_mammillotegmentalTract.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialEntorhinalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialEntorhinalCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialGeniculateBodyDorsalDivision.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialGeniculateBodyDorsalDivision.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialGeniculateBodyMarginalZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialGeniculateBodyMarginalZone.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialGeniculateBodyMedialDivision.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialGeniculateBodyMedialDivision.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialGeniculateBodySuprageniculateNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialGeniculateBodySuprageniculateNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialGeniculateBodyVentralDivision.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialGeniculateBodyVentralDivision.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialHabenularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialHabenularNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialLemniscusDecussation.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialLemniscusDecussation.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialLemniscusUnspecified.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialLemniscusUnspecified.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialOrbitalArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialOrbitalArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialSuperiorOlive.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialSuperiorOlive.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_mediodorsalThalamicNucleusCentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_mediodorsalThalamicNucleusCentralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_mediodorsalThalamicNucleusLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_mediodorsalThalamicNucleusLateralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_mediodorsalThalamicNucleusMedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_mediodorsalThalamicNucleusMedialPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_middleCerebellarPeduncle.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_middleCerebellarPeduncle.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_molecularCellLayerOfTheCerebellum.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_molecularCellLayerOfTheCerebellum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_nucleusAccumbensCore.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_nucleusAccumbensCore.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_nucleusAccumbensShell.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_nucleusAccumbensShell.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_nucleusOfTheLateralOlfactoryTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_nucleusOfTheLateralOlfactoryTract.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_nucleusOfTheStriaMedullaris.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_nucleusOfTheStriaMedullaris.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_nucleusOfTheTrapezoidBody.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_nucleusOfTheTrapezoidBody.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_nucleusSagulum.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_nucleusSagulum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_olfactoryBulbUnspecified.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_olfactoryBulbUnspecified.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_opticNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_opticNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_opticTractAndOpticChiasm.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_opticTractAndOpticChiasm.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_paracentralThalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_paracentralThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_parafascicularThalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_parafascicularThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_parasubiculum.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_parasubiculum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_parataenialThalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_parataenialThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_paraventricularThalamicNucleiAnteriorAndPosterior.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_paraventricularThalamicNucleiAnteriorAndPosterior.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_parietalAssociationCortexLateralArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_parietalAssociationCortexLateralArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_parietalAssociationCortexMedialArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_parietalAssociationCortexMedialArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_parietalAssociationCortexPosteriorArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_parietalAssociationCortexPosteriorArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_periaqueductalGray.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_periaqueductalGray.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_peripeduncularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_peripeduncularNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_perirhinalArea35.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_perirhinalArea35.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_perirhinalArea36.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_perirhinalArea36.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_periventricularGray.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_periventricularGray.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_pinealGland.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_pinealGland.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_piriformCortexLayer1.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_piriformCortexLayer1.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_piriformCortexLayer2.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_piriformCortexLayer2.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_piriformCortexLayer3.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_piriformCortexLayer3.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_pontineNuclei.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_pontineNuclei.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_posteriorCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_posteriorCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_posteriorIntralaminarNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_posteriorIntralaminarNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_posteriorThalamicNuclearGroupTriangularPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_posteriorThalamicNuclearGroupTriangularPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_posteriorThalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_posteriorThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_postrhinalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_postrhinalCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_pregeniculateNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_pregeniculateNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_prelimbicArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_prelimbicArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_presubiculum.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_presubiculum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_pretectalRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_pretectalRegion.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_pretectothalamicLamina.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_pretectothalamicLamina.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_primaryAuditoryArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_primaryAuditoryArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_primaryMotorArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_primaryMotorArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_primarySomatosensoryAreaBarrelField.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_primarySomatosensoryAreaBarrelField.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_primarySomatosensoryAreaDysgranularZone.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_primarySomatosensoryAreaDysgranularZone.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_primarySomatosensoryAreaFaceRepresentation.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_primarySomatosensoryAreaFaceRepresentation.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_primarySomatosensoryAreaForelimbRepresentation.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_primarySomatosensoryAreaForelimbRepresentation.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_primarySomatosensoryAreaHindlimbRepresentation.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_primarySomatosensoryAreaHindlimbRepresentation.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_primarySomatosensoryAreaTrunkRepresentation.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_primarySomatosensoryAreaTrunkRepresentation.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_primaryVisualArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_primaryVisualArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_pyramidalDecussation.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_pyramidalDecussation.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_reticularPrethalamicNucleusAuditorySegment.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_reticularPrethalamicNucleusAuditorySegment.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_reticularPrethalamicNucleusUnspecified.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_reticularPrethalamicNucleusUnspecified.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_retroreuniensThalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_retroreuniensThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_retrosplenialDysgranularArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_retrosplenialDysgranularArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_retrosplenialGranularArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_retrosplenialGranularArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_reuniensThalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_reuniensThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_rhomboidThalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_rhomboidThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_secondaryAuditoryAreaDorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_secondaryAuditoryAreaDorsalPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_secondaryAuditoryAreaVentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_secondaryAuditoryAreaVentralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_secondaryMotorArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_secondaryMotorArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_secondarySomatosensoryArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_secondarySomatosensoryArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_secondaryVisualAreaLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_secondaryVisualAreaLateralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_secondaryVisualAreaMedialPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_secondaryVisualAreaMedialPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_septalRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_septalRegion.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_spinalCord.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_spinalCord.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_spinalTrigeminalNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_spinalTrigeminalNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_spinalTrigeminalTract.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_spinalTrigeminalTract.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_spiralGanglion.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_spiralGanglion.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_striaMedullarisThalami.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_striaMedullarisThalami.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_striaTerminalis.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_striaTerminalis.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_subgeniculateNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_subgeniculateNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_subiculum.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_subiculum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_submediusThalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_submediusThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_subparafascicularNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_subparafascicularNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_substantiaNigraCompactPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_substantiaNigraCompactPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_substantiaNigraLateralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_substantiaNigraLateralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_substantiaNigraReticularPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_substantiaNigraReticularPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_subthalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_subthalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_superficialGrayLayerOfTheSuperiorColliculus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_superficialGrayLayerOfTheSuperiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_superiorCerebellarPeduncleAndPrerubralField.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_superiorCerebellarPeduncleAndPrerubralField.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_superiorParaolivaryNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_superiorParaolivaryNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_superiorPeriolivaryRegion.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_superiorPeriolivaryRegion.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_supraopticDecussation.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_supraopticDecussation.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_temporalAssociationCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_temporalAssociationCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_transverseFibersOfThePons.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_transverseFibersOfThePons.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_trapezoidBody.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_trapezoidBody.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralAnteriorThalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralAnteriorThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralCochlearNucleusAnteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralCochlearNucleusAnteriorPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralCochlearNucleusCapArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralCochlearNucleusCapArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralCochlearNucleusGranuleCellLayer.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralCochlearNucleusGranuleCellLayer.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralCochlearNucleusPosteriorPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralCochlearNucleusPosteriorPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralHippocampalCommissure.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralHippocampalCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralOrbitalArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralOrbitalArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralPallidum.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralPallidum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralPeriolivaryNuclei.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralPeriolivaryNuclei.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralPosteriorNucleusOfTheThalamusParvicellularPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralPosteriorNucleusOfTheThalamusParvicellularPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralPosterolateralThalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralPosterolateralThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralPosteromedialThalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralPosteromedialThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralStriatalRegionUnspecified.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralStriatalRegionUnspecified.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralTegmentalArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralTegmentalArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventricularSystemUnspecified.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventricularSystemUnspecified.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventrolateralOrbitalArea.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventrolateralOrbitalArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventrolateralThalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventrolateralThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventromedialThalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventromedialThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_vestibularApparatus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_vestibularApparatus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_vestibularNerve.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_vestibularNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_xiphoidThalamicNucleus.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_xiphoidThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_zonaIncertaA11DopamineCells.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_zonaIncertaA11DopamineCells.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_zonaIncertaA13DopamineCells.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_zonaIncertaA13DopamineCells.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_zonaIncertaCaudalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_zonaIncertaCaudalPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_zonaIncertaDorsalPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_zonaIncertaDorsalPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_zonaIncertaRostralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_zonaIncertaRostralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_zonaIncertaVentralPart.jsonld
+++ b/instances/latest/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_zonaIncertaVentralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_ACIN.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_ACIN.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_AG.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_AG.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_AMYG.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_AMYG.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_CAU.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_CAU.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_F1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_F1.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_F1M.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_F1M.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_F1MO.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_F1MO.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_F1O.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_F1O.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_F2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_F2.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_F2O.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_F2O.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_F3O.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_F3O.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_F3OP.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_F3OP.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_F3T.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_F3T.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_FUSI.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_FUSI.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_GR.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_GR.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_HES.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_HES.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_HIP.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_HIP.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_IN.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_IN.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_LING.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_LING.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_MCIN.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_MCIN.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_O1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_O1.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_O2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_O2.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_O3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_O3.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_OC.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_OC.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_P1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_P1.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_P2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_P2.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_PAL.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_PAL.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_PCIN.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_PCIN.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_PCL.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_PCL.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_PHIP.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_PHIP.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_POST.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_POST.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_PQ.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_PQ.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_PRE.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_PRE.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_PUT.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_PUT.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_Q.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_Q.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_RO.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_RO.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_SMA.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_SMA.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_SMG.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_SMG.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_T1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_T1.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_T1P.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_T1P.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_T2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_T2.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_T2P.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_T2P.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_T3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_T3.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_THA.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_THA.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_V1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AAL1_SPM12-v4/AAL1_SPM12-v4_V1.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -33,7 +32,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_abducensNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_abducensNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_abducensNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_abducensNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_accessoryAbducensNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_accessoryAbducensNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_accessoryFacialMotorNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_accessoryFacialMotorNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_accessoryOlfactoryBulb.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_accessoryOlfactoryBulb.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_accessoryOlfactoryBulbGlomerularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_accessoryOlfactoryBulbGlomerularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_accessoryOlfactoryBulbGranularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_accessoryOlfactoryBulbGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_accessoryOlfactoryBulbMitralLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_accessoryOlfactoryBulbMitralLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_accessoryOlfactoryTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_accessoryOlfactoryTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_accessoryOpticTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_accessoryOpticTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_accessorySpinalNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_accessorySpinalNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_accessorySupraopticGroup.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_accessorySupraopticGroup.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaDorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaDorsalPartLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaDorsalPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaDorsalPartLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaDorsalPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaDorsalPartLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaDorsalPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaDorsalPartLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaDorsalPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaDorsalPartLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaDorsalPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaPosteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaPosteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaPosteriorPartLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaPosteriorPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaPosteriorPartLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaPosteriorPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaPosteriorPartLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaPosteriorPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaPosteriorPartLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaPosteriorPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaPosteriorPartLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaPosteriorPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaVentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaVentralPartLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaVentralPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaVentralPartLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaVentralPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaVentralPartLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaVentralPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaVentralPartLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaVentralPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaVentralPartLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_agranularInsularAreaVentralPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_alveus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_alveus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ammonsHorn.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ammonsHorn.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_amygdalarCapsule.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_amygdalarCapsule.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_angularPath.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_angularPath.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ansaPeduncularis.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ansaPeduncularis.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ansiformLobule.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ansiformLobule.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ansoparamedianFissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ansoparamedianFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorAmygdalarArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorAmygdalarArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaDorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaDorsalPartLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaDorsalPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaDorsalPartLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaDorsalPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaDorsalPartLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaDorsalPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaDorsalPartLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaDorsalPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaDorsalPartLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaDorsalPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaVentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaVentralPart6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaVentralPart6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaVentralPart6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaVentralPart6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaVentralPartLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaVentralPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaVentralPartLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaVentralPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaVentralPartLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCingulateAreaVentralPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCommissureOlfactoryLimb.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCommissureOlfactoryLimb.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCommissureTemporalLimb.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorCommissureTemporalLimb.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorGroupOfTheDorsalThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorGroupOfTheDorsalThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorHypothalamicArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorHypothalamicArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorHypothalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorHypothalamicNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorHypothalamicNucleusAnteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorHypothalamicNucleusAnteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorHypothalamicNucleusCentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorHypothalamicNucleusCentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorHypothalamicNucleusDorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorHypothalamicNucleusDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorHypothalamicNucleusPosteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorHypothalamicNucleusPosteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorOlfactoryNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorOlfactoryNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorOlfactoryNucleusDorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorOlfactoryNucleusDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorOlfactoryNucleusExternalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorOlfactoryNucleusExternalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorOlfactoryNucleusLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorOlfactoryNucleusLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorOlfactoryNucleusLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorOlfactoryNucleusLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorOlfactoryNucleusLayer2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorOlfactoryNucleusLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorOlfactoryNucleusMedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorOlfactoryNucleusMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorOlfactoryNucleusPosteroventralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorOlfactoryNucleusPosteroventralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorPretectalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorPretectalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorTegmentalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteriorTegmentalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anterodorsalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anterodorsalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anterodorsalPreopticNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anterodorsalPreopticNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anterolateralVisualArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anterolateralVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anterolateralVisualAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anterolateralVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anterolateralVisualAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anterolateralVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anterolateralVisualAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anterolateralVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anterolateralVisualAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anterolateralVisualAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anterolateralVisualAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anterolateralVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anterolateralVisualAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anterolateralVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteromedialNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteromedialNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteromedialNucleusDorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteromedialNucleusDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteromedialNucleusVentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteromedialNucleusVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteromedialVisualArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteromedialVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteromedialVisualAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteromedialVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteromedialVisualAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteromedialVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteromedialVisualAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteromedialVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteromedialVisualAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteromedialVisualAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteromedialVisualAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteromedialVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteromedialVisualAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteromedialVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteroventralNucleusOfThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteroventralNucleusOfThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteroventralPeriventricularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteroventralPeriventricularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteroventralPreopticNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_anteroventralPreopticNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_arborVitae.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_arborVitae.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_arcuateHypothalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_arcuateHypothalamicNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_areaPostrema.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_areaPostrema.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_areaProstriata.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_areaProstriata.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_auditoryAreas.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_auditoryAreas.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_auditoryRadiation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_auditoryRadiation.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_barringtonsNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_barringtonsNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_basicCellGroupsAndRegions.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_basicCellGroupsAndRegions.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_basolateralAmygdalarNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_basolateralAmygdalarNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_basolateralAmygdalarNucleusAnteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_basolateralAmygdalarNucleusAnteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_basolateralAmygdalarNucleusPosteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_basolateralAmygdalarNucleusPosteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_basolateralAmygdalarNucleusVentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_basolateralAmygdalarNucleusVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_basomedialAmygdalarNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_basomedialAmygdalarNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_basomedialAmygdalarNucleusAnteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_basomedialAmygdalarNucleusAnteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_basomedialAmygdalarNucleusPosteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_basomedialAmygdalarNucleusPosteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalis.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalis.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisAnteriorDivision.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisAnteriorDivision.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisAnteriorDivisionAnterolateralArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisAnteriorDivisionAnterolateralArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisAnteriorDivisionAnteromedialArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisAnteriorDivisionAnteromedialArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisAnteriorDivisionDorsomedialNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisAnteriorDivisionDorsomedialNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisAnteriorDivisionFusiformNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisAnteriorDivisionFusiformNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisAnteriorDivisionJuxtacapsularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisAnteriorDivisionJuxtacapsularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisAnteriorDivisionMagnocellularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisAnteriorDivisionMagnocellularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisAnteriorDivisionOvalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisAnteriorDivisionOvalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisAnteriorDivisionRhomboidNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisAnteriorDivisionRhomboidNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisAnteriorDivisionVentralNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisAnteriorDivisionVentralNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisPosteriorDivision.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisPosteriorDivision.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisPosteriorDivisionDorsalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisPosteriorDivisionDorsalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisPosteriorDivisionInterfascicularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisPosteriorDivisionInterfascicularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisPosteriorDivisionPrincipalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisPosteriorDivisionPrincipalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisPosteriorDivisionStrialExtension.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisPosteriorDivisionStrialExtension.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisPosteriorDivisionTransverseNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleiOfTheStriaTerminalisPosteriorDivisionTransverseNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleusOfTheAccessoryOlfactoryTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleusOfTheAccessoryOlfactoryTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleusOfTheAnteriorCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bedNucleusOfTheAnteriorCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_brachiumOfTheInferiorColliculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_brachiumOfTheInferiorColliculus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_brachiumOfTheSuperiorColliculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_brachiumOfTheSuperiorColliculus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_brainStem.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_brainStem.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bulbocerebellarTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_bulbocerebellarTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_caudoputamen.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_caudoputamen.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_centralAmygdalarNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_centralAmygdalarNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_centralAmygdalarNucleusCapsularPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_centralAmygdalarNucleusCapsularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_centralAmygdalarNucleusLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_centralAmygdalarNucleusLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_centralAmygdalarNucleusMedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_centralAmygdalarNucleusMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_centralCanalSpinalCordmedulla.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_centralCanalSpinalCordmedulla.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_centralLateralNucleusOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_centralLateralNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_centralLinearNucleusRaphe.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_centralLinearNucleusRaphe.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_centralLobule.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_centralLobule.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_centralMedialNucleusOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_centralMedialNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_centralTegmentalBundle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_centralTegmentalBundle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebalPeduncle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebalPeduncle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebellarCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebellarCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebellarCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebellarCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebellarCortexGranularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebellarCortexGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebellarCortexMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebellarCortexMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebellarCortexPurkinjeLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebellarCortexPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebellarNuclei.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebellarNuclei.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebellarPeduncles.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebellarPeduncles.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebellum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebellum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebellumRelatedFiberTracts.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebellumRelatedFiberTracts.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebralAqueduct.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebralAqueduct.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebralCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebralCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebralNuclei.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebralNuclei.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebralNucleiRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebralNucleiRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebrum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebrum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebrumRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cerebrumRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cervicothalamicTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cervicothalamicTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_choroidFissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_choroidFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_choroidPlexus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_choroidPlexus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cingulumBundle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cingulumBundle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_claustrum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_claustrum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cochlearNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cochlearNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cochlearNuclei.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cochlearNuclei.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cochlearNucleusSubpedunclularGranularRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cochlearNucleusSubpedunclularGranularRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_columnsOfTheFornix.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_columnsOfTheFornix.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_commissuralBranchOfStriaTerminalis.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_commissuralBranchOfStriaTerminalis.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_copulaPyramidis.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_copulaPyramidis.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_copulaPyramidisGranularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_copulaPyramidisGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_copulaPyramidisMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_copulaPyramidisMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_copulaPyramidisPurkinjeLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_copulaPyramidisPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corpusCallosum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corpusCallosum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corpusCallosumAnteriorForceps.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corpusCallosumAnteriorForceps.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corpusCallosumBody.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corpusCallosumBody.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corpusCallosumExtremeCapsule.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corpusCallosumExtremeCapsule.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corpusCallosumPosteriorForceps.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corpusCallosumPosteriorForceps.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corpusCallosumRostrum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corpusCallosumRostrum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corpusCallosumSplenium.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corpusCallosumSplenium.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaAnteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaAnteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaAnteriorPartLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaAnteriorPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaAnteriorPartLayer2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaAnteriorPartLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaAnteriorPartLayer3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaAnteriorPartLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartLateralZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartLateralZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartLateralZoneLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartLateralZoneLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartLateralZoneLayer2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartLateralZoneLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartLateralZoneLayer3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartLateralZoneLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartLateralZoneLayers12.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartLateralZoneLayers12.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartLateralZoneLayers13.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartLateralZoneLayers13.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartMedialZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartMedialZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartMedialZoneLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartMedialZoneLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartMedialZoneLayer2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartMedialZoneLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartMedialZoneLayer3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartMedialZoneLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartMedialZoneLayers12.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartMedialZoneLayers12.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartMedialZoneLayers13.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalAmygdalarAreaPosteriorPartMedialZoneLayers13.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalPlate.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalPlate.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalSubplate.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticalSubplate.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticobulbarTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticobulbarTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticopontineTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticopontineTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticorubralTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticorubralTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticospinalTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticospinalTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticospinalTractCrossed.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticospinalTractCrossed.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticospinalTractUncrossed.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticospinalTractUncrossed.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticotectalTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_corticotectalTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cranialNerves.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cranialNerves.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_crossedTectospinalPathway.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_crossedTectospinalPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_crus1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_crus1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_crus1GranularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_crus1GranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_crus1MolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_crus1MolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_crus1PurkinjeLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_crus1PurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_crus2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_crus2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_crus2GranularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_crus2GranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_crus2MolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_crus2MolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_crus2PurkinjeLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_crus2PurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_culmen.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_culmen.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cuneateFascicle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cuneateFascicle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cuneateNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cuneateNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cuneiformNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cuneiformNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cuneocerebellarTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_cuneocerebellarTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_decliveVI.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_decliveVI.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_decliveVIGranularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_decliveVIGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_decliveVIMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_decliveVIMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_decliveVIPurkinjeLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_decliveVIPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusCrest.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusCrest.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusCrestGranuleCellLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusCrestGranuleCellLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusCrestMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusCrestMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusCrestPolymorphLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusCrestPolymorphLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusGranuleCellLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusGranuleCellLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusLateralBlade.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusLateralBlade.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusLateralBladeGranuleCellLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusLateralBladeGranuleCellLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusLateralBladeMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusLateralBladeMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusLateralBladePolymorphLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusLateralBladePolymorphLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusMedialBlade.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusMedialBlade.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusMedialBladeGranuleCellLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusMedialBladeGranuleCellLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusMedialBladeMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusMedialBladeMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusMedialBladePolymorphLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusMedialBladePolymorphLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusPolymorphLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusPolymorphLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusSubgranularZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateGyrusSubgranularZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dentateNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_diagonalBandNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_diagonalBandNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_directTectospinalPathway.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_directTectospinalPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dopaminergicA13Group.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dopaminergicA13Group.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_doralTegmentalDecussation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_doralTegmentalDecussation.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalAcousticStria.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalAcousticStria.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalAuditoryArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalAuditoryArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalAuditoryAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalAuditoryAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalAuditoryAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalAuditoryAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalAuditoryAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalAuditoryAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalAuditoryAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalAuditoryAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalAuditoryAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalAuditoryAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalAuditoryAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalAuditoryAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalCochlearNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalCochlearNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalColumn.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalColumn.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalColumnNuclei.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalColumnNuclei.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalCommissureOfTheSpinalCord.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalCommissureOfTheSpinalCord.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalFornix.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalFornix.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalHippocampalCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalHippocampalCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalLimb.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalLimb.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalLongitudinalFascicle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalLongitudinalFascicle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalMotorNucleusOfTheVagusNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalMotorNucleusOfTheVagusNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalNucleusRaphe.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalNucleusRaphe.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPartOfTheLateralGeniculateComplex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPartOfTheLateralGeniculateComplex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPartOfTheLateralGeniculateComplexCore.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPartOfTheLateralGeniculateComplexCore.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPartOfTheLateralGeniculateComplexIpsilateralZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPartOfTheLateralGeniculateComplexIpsilateralZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPartOfTheLateralGeniculateComplexShell.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPartOfTheLateralGeniculateComplexShell.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPeduncularArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPeduncularArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPeduncularAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPeduncularAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPeduncularAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPeduncularAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPeduncularAreaLayer2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPeduncularAreaLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPeduncularAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPeduncularAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPeduncularAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPeduncularAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPremammillaryNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalPremammillaryNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalRoots.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalRoots.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalSpinocerebellarTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalSpinocerebellarTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalTegmentalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalTegmentalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalTegmentalTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalTegmentalTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalTerminalNucleusOfTheAccessoryOpticTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalTerminalNucleusOfTheAccessoryOpticTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalThalamusRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsalThalamusRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsolateralFascicle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsolateralFascicle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsomedialNucleusOfTheHypothalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsomedialNucleusOfTheHypothalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsomedialNucleusOfTheHypothalamusAnteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsomedialNucleusOfTheHypothalamusAnteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsomedialNucleusOfTheHypothalamusPosteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsomedialNucleusOfTheHypothalamusPosteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsomedialNucleusOfTheHypothalamusVentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_dorsomedialNucleusOfTheHypothalamusVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ectorhinalArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ectorhinalArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ectorhinalAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ectorhinalAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ectorhinalAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ectorhinalAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ectorhinalAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ectorhinalAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ectorhinalAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ectorhinalAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ectorhinalAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ectorhinalAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_edingerWestphalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_edingerWestphalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_efferentCochlearGroup.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_efferentCochlearGroup.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_efferentCochleovestibularBundle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_efferentCochleovestibularBundle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_efferentVestibularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_efferentVestibularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_endopiriformNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_endopiriformNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_endopiriformNucleusDorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_endopiriformNucleusDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_endopiriformNucleusVentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_endopiriformNucleusVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_endorhinalGroove.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_endorhinalGroove.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer2a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer2a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer2b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer2b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer4-5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer4-5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer5-6.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer5-6.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaLateralPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartDorsalZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartDorsalZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartDorsalZoneLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartDorsalZoneLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartDorsalZoneLayer2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartDorsalZoneLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartDorsalZoneLayer2a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartDorsalZoneLayer2a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartDorsalZoneLayer2b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartDorsalZoneLayer2b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartDorsalZoneLayer3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartDorsalZoneLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartDorsalZoneLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartDorsalZoneLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartDorsalZoneLayer5-6.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartDorsalZoneLayer5-6.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartDorsalZoneLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartDorsalZoneLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartDorsalZoneLayer6.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartDorsalZoneLayer6.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartVentralZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartVentralZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartVentralZoneLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartVentralZoneLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartVentralZoneLayer2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartVentralZoneLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartVentralZoneLayer3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartVentralZoneLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartVentralZoneLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartVentralZoneLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartVentralZoneLayer5-6.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_entorhinalAreaMedialPartVentralZoneLayer5-6.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_epithalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_epithalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_epithalamusRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_epithalamusRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_externalCapsule.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_externalCapsule.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_externalCuneateNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_externalCuneateNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_externalMedullaryLaminaOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_externalMedullaryLaminaOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_extrapyramidalFiberSystems.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_extrapyramidalFiberSystems.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_facialMotorNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_facialMotorNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_facialNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_facialNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fasciculusProprius.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fasciculusProprius.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fasciculusRetroflexus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fasciculusRetroflexus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fasciolaCinerea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fasciolaCinerea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fastigialNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fastigialNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fiberTracts.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fiberTracts.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA1PyramidalLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA1PyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA1StratumLacunosummoleculare.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA1StratumLacunosummoleculare.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA1StratumOriens.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA1StratumOriens.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA1StratumRadiatum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA1StratumRadiatum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA2PyramidalLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA2PyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA2StratumLacunosummoleculare.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA2StratumLacunosummoleculare.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA2StratumOriens.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA2StratumOriens.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA2StratumRadiatum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA2StratumRadiatum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA3PyramidalLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA3PyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA3StratumLacunosummoleculare.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA3StratumLacunosummoleculare.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA3StratumLucidum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA3StratumLucidum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA3StratumOriens.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA3StratumOriens.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA3StratumRadiatum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldCA3StratumRadiatum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldsOfForel.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fieldsOfForel.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fimbria.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fimbria.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_flocculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_flocculus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_flocculusGranularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_flocculusGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_flocculusMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_flocculusMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_flocculusPurkinjeLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_flocculusPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_foliumtuberVermisVII.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_foliumtuberVermisVII.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_foliumtuberVermisVIIGranularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_foliumtuberVermisVIIGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_foliumtuberVermisVIIMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_foliumtuberVermisVIIMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_foliumtuberVermisVIIPurkinjeLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_foliumtuberVermisVIIPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fornixSystem.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fornixSystem.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fourthVentricle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fourthVentricle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_frontalPoleCerebralCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_frontalPoleCerebralCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_frontalPoleLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_frontalPoleLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_frontalPoleLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_frontalPoleLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fundusOfStriatum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_fundusOfStriatum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_geniculateGroupDorsalThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_geniculateGroupDorsalThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_geniculateGroupVentralThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_geniculateGroupVentralThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_genuOfCorpusCallosum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_genuOfCorpusCallosum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_genuOfTheFacialNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_genuOfTheFacialNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_gigantocellularReticularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_gigantocellularReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_globusPallidusExternalSegment.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_globusPallidusExternalSegment.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_globusPallidusInternalSegment.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_globusPallidusInternalSegment.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_glossopharyngealNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_glossopharyngealNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_gracileFascicle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_gracileFascicle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_gracileNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_gracileNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_granularLaminaOfTheCochlearNuclei.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_granularLaminaOfTheCochlearNuclei.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_grooves.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_grooves.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_groovesOfTheCerebellarCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_groovesOfTheCerebellarCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_groovesOfTheCerebralCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_groovesOfTheCerebralCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_gustatoryAreas.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_gustatoryAreas.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_gustatoryAreasLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_gustatoryAreasLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_gustatoryAreasLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_gustatoryAreasLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_gustatoryAreasLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_gustatoryAreasLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_gustatoryAreasLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_gustatoryAreasLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_gustatoryAreasLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_gustatoryAreasLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_gustatoryAreasLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_gustatoryAreasLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_habenularCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_habenularCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hemisphericRegions.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hemisphericRegions.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hindbrain.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hindbrain.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hippocampalCommissures.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hippocampalCommissures.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hippocampalFissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hippocampalFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hippocampalFormation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hippocampalFormation.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hippocampalRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hippocampalRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hypoglossalNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hypoglossalNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hypoglossalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hypoglossalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hypothalamicLateralZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hypothalamicLateralZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hypothalamicMedialZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hypothalamicMedialZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hypothalamohypophysialTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hypothalamohypophysialTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hypothalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hypothalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hypothalamusRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_hypothalamusRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_induseumGriseum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_induseumGriseum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_inferiorCerebellarPeduncle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_inferiorCerebellarPeduncle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_inferiorColliculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_inferiorColliculus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_inferiorColliculusCentralNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_inferiorColliculusCentralNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_inferiorColliculusCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_inferiorColliculusCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_inferiorColliculusDorsalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_inferiorColliculusDorsalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_inferiorColliculusExternalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_inferiorColliculusExternalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_inferiorOlivaryComplex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_inferiorOlivaryComplex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_inferiorSalivatoryNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_inferiorSalivatoryNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_infracerebellarNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_infracerebellarNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_infralimbicArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_infralimbicArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_infralimbicAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_infralimbicAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_infralimbicAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_infralimbicAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_infralimbicAreaLayer2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_infralimbicAreaLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_infralimbicAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_infralimbicAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_infralimbicAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_infralimbicAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_infralimbicAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_infralimbicAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_interanterodorsalNucleusOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_interanterodorsalNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_interanteromedialNucleusOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_interanteromedialNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_interbrain.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_interbrain.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_intercalatedAmygdalarNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_intercalatedAmygdalarNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_intercruralFissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_intercruralFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_interfascicularNucleusRaphe.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_interfascicularNucleusRaphe.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_intergeniculateLeafletOfTheLateralGeniculateComplex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_intergeniculateLeafletOfTheLateralGeniculateComplex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_intermediateAcousticStria.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_intermediateAcousticStria.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_intermediateNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_intermediateNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_intermediateReticularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_intermediateReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_intermediodorsalNucleusOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_intermediodorsalNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_internalArcuateFibers.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_internalArcuateFibers.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_internalCapsule.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_internalCapsule.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_internalMedullaryLaminaOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_internalMedullaryLaminaOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_interpeduncularFossa.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_interpeduncularFossa.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_interpeduncularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_interpeduncularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_interposedNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_interposedNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_interstitialNucleusOfCajal.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_interstitialNucleusOfCajal.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_interstitialNucleusOfTheVestibularNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_interstitialNucleusOfTheVestibularNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_interventricularForamen.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_interventricularForamen.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_intralaminarNucleiOfTheDorsalThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_intralaminarNucleiOfTheDorsalThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_intraparafloccularFissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_intraparafloccularFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_islandsOfCalleja.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_islandsOfCalleja.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_isocortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_isocortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_juxtarestiformBody.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_juxtarestiformBody.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_koellikerFuseSubnucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_koellikerFuseSubnucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralAmygdalarNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralAmygdalarNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralDorsalNucleusOfThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralDorsalNucleusOfThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralForebrainBundleSystem.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralForebrainBundleSystem.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralGroupOfTheDorsalThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralGroupOfTheDorsalThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralHabenula.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralHabenula.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralHypothalamicArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralHypothalamicArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralLemniscus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralLemniscus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralMammillaryNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralMammillaryNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralOlfactoryTractBody.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralOlfactoryTractBody.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralOlfactoryTractGeneral.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralOlfactoryTractGeneral.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralPosteriorNucleusOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralPosteriorNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralPreopticArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralPreopticArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralRecess.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralRecess.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralReticularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralReticularNucleusMagnocellularPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralReticularNucleusMagnocellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralReticularNucleusParvicellularPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralReticularNucleusParvicellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralSeptalComplex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralSeptalComplex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralSeptalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralSeptalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralSeptalNucleusCaudalCaudodorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralSeptalNucleusCaudalCaudodorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralSeptalNucleusRostralRostroventralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralSeptalNucleusRostralRostroventralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralSeptalNucleusVentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralSeptalNucleusVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralSpinothalamicTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralSpinothalamicTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralTegmentalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralTegmentalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralTerminalNucleusOfTheAccessoryOpticTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralTerminalNucleusOfTheAccessoryOpticTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralVentricle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralVentricle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralVestibularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralVestibularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralVisualArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralVisualAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralVisualAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralVisualAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralVisualAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralVisualAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralVisualAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralVisualAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lateralVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterodorsalTegmentalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterodorsalTegmentalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterointermediateArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterointermediateArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterointermediateAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterointermediateAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterointermediateAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterointermediateAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterointermediateAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterointermediateAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterointermediateAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterointermediateAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterointermediateAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterointermediateAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterointermediateAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterointermediateAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterolateralAnteriorVisualArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterolateralAnteriorVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterolateralAnteriorVisualAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterolateralAnteriorVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterolateralAnteriorVisualAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterolateralAnteriorVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterolateralAnteriorVisualAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterolateralAnteriorVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterolateralAnteriorVisualAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterolateralAnteriorVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterolateralAnteriorVisualAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterolateralAnteriorVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterolateralAnteriorVisualArealayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_laterolateralAnteriorVisualArealayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_layer6bIsocortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_layer6bIsocortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_linearNucleusOfTheMedulla.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_linearNucleusOfTheMedulla.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lingulaI.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lingulaI.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lingulaIGranularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lingulaIGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lingulaIMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lingulaIMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lingulaIPurkinjeLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lingulaIPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleII.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleII.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIIGranularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIIGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIII.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIII.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIIIGranularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIIIGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIIIMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIIIMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIIIPurkinjeLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIIIPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIIMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIIMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIIPurkinjeLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIIPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIV.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIV.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIVGranularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIVGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIVMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIVMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIVPurkinjeLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleIVPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleV.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleV.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleVGranularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleVGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleVMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleVMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleVPurkinjeLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobuleVPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobulesIV-V.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobulesIV-V.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobulesIV-VGranularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobulesIV-VGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobulesIV-VMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobulesIV-VMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobulesIV-VPurkinjeLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_lobulesIV-VPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_locusCeruleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_locusCeruleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_longitudinalAssociationBundle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_longitudinalAssociationBundle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_magnocellularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_magnocellularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_magnocellularReticularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_magnocellularReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mainOlfactoryBulb.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mainOlfactoryBulb.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mainOlfactoryBulbGlomerularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mainOlfactoryBulbGlomerularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mainOlfactoryBulbGranuleLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mainOlfactoryBulbGranuleLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mainOlfactoryBulbInnerPlexiformLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mainOlfactoryBulbInnerPlexiformLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mainOlfactoryBulbMitralLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mainOlfactoryBulbMitralLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mainOlfactoryBulbOuterPlexiformLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mainOlfactoryBulbOuterPlexiformLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_majorIslandOfCalleja.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_majorIslandOfCalleja.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mammillaryBody.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mammillaryBody.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mammillaryPeduncle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mammillaryPeduncle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mammillaryRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mammillaryRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mammillotegmentalTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mammillotegmentalTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mammilothalmicTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mammilothalmicTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialAmygdalarNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialAmygdalarNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialAmygdalarNucleusAnterodorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialAmygdalarNucleusAnterodorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialAmygdalarNucleusAnteroventralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialAmygdalarNucleusAnteroventralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialAmygdalarNucleusPosterodorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialAmygdalarNucleusPosterodorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialAmygdalarNucleusPosterodorsalPartSublayerA.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialAmygdalarNucleusPosterodorsalPartSublayerA.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialAmygdalarNucleusPosterodorsalPartSublayerB.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialAmygdalarNucleusPosterodorsalPartSublayerB.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialAmygdalarNucleusPosterodorsalPartSublayerC.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialAmygdalarNucleusPosterodorsalPartSublayerC.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialAmygdalarNucleusPosteroventralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialAmygdalarNucleusPosteroventralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialCorticohypothalmicTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialCorticohypothalmicTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialForebrainBundle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialForebrainBundle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialForebrainBundleSystem.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialForebrainBundleSystem.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialGeniculateComplex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialGeniculateComplex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialGeniculateComplexDorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialGeniculateComplexDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialGeniculateComplexMedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialGeniculateComplexMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialGeniculateComplexVentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialGeniculateComplexVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialGroupOfTheDorsalThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialGroupOfTheDorsalThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialHabenula.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialHabenula.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialLemniscus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialLemniscus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialLongitudinalFascicle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialLongitudinalFascicle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialMammillaryNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialMammillaryNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialMammillaryNucleusMedianPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialMammillaryNucleusMedianPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialPreopticArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialPreopticArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialPreopticNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialPreopticNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialPreopticNucleusCentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialPreopticNucleusCentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialPreopticNucleusLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialPreopticNucleusLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialPreopticNucleusMedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialPreopticNucleusMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialPretectalArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialPretectalArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialSeptalComplex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialSeptalComplex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialSeptalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialSeptalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialTerminalNucleusOfTheAccessoryOpticTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialTerminalNucleusOfTheAccessoryOpticTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialVestibularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialVestibularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialVisualArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialVisualAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialVisualAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialVisualAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialVisualAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialVisualAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialVisualArealayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medialVisualArealayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medianEminence.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medianEminence.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medianPreopticNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medianPreopticNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediodorsalNucleusOfThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediodorsalNucleusOfThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediodorsalNucleusOfTheThalamusCentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediodorsalNucleusOfTheThalamusCentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediodorsalNucleusOfTheThalamusLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediodorsalNucleusOfTheThalamusLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediodorsalNucleusOfTheThalamusMedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediodorsalNucleusOfTheThalamusMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialAnteriorVisualArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialAnteriorVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialAnteriorVisualAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialAnteriorVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialAnteriorVisualAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialAnteriorVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialAnteriorVisualAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialAnteriorVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialAnteriorVisualAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialAnteriorVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialAnteriorVisualAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialAnteriorVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialAnteriorVisualArealayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialAnteriorVisualArealayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialPosteriorVisualArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialPosteriorVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialPosteriorVisualAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialPosteriorVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialPosteriorVisualAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialPosteriorVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialPosteriorVisualAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialPosteriorVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialPosteriorVisualAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialPosteriorVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialPosteriorVisualAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialPosteriorVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialPosteriorVisualArealayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_mediomedialPosteriorVisualArealayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medulla.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medulla.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medullaBehavioralStateRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medullaBehavioralStateRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medullaMotorRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medullaMotorRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medullaSensoryRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medullaSensoryRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medullaryReticularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medullaryReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medullaryReticularNucleusDorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medullaryReticularNucleusDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medullaryReticularNucleusVentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_medullaryReticularNucleusVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrain.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrain.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainBehavioralStateRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainBehavioralStateRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainMotorRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainMotorRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainRapheNuclei.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainRapheNuclei.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainReticularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainReticularNucleusMagnocellularPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainReticularNucleusMagnocellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainReticularNucleusMagnocellularPartGeneral.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainReticularNucleusMagnocellularPartGeneral.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainReticularNucleusParvicellularPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainReticularNucleusParvicellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainReticularNucleusRetrorubralArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainReticularNucleusRetrorubralArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainSensoryRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainSensoryRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainTractOfTheTrigeminalNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainTractOfTheTrigeminalNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainTrigeminalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midbrainTrigeminalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_middleCerebellarPeduncle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_middleCerebellarPeduncle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_middleThalamicCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_middleThalamicCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midlineGroupOfTheDorsalThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_midlineGroupOfTheDorsalThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_motorNucleusOfTrigeminal.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_motorNucleusOfTrigeminal.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_motorRootOfTheTrigeminalNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_motorRootOfTheTrigeminalNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nigrostriatalTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nigrostriatalTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nigrothalamicFibers.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nigrothalamicFibers.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nodularFissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nodularFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nodulusX.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nodulusX.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nodulusXGranularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nodulusXGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nodulusXMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nodulusXMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nodulusXPurkinjeLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nodulusXPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusAccumbens.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusAccumbens.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusAmbiguus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusAmbiguus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusAmbiguusDorsalDivision.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusAmbiguusDorsalDivision.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusAmbiguusVentralDivision.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusAmbiguusVentralDivision.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusCircularis.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusCircularis.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusIncertus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusIncertus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusIntercalatus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusIntercalatus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfDarkschewitsch.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfDarkschewitsch.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfReunions.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfReunions.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfRoller.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfRoller.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheBrachiumOfTheInferiorColliculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheBrachiumOfTheInferiorColliculus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheLateralLemniscus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheLateralLemniscus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheLateralLemniscusDorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheLateralLemniscusDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheLateralLemniscusHorizontalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheLateralLemniscusHorizontalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheLateralLemniscusVentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheLateralLemniscusVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheLateralOlfactoryTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheLateralOlfactoryTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheLateralOlfactoryTractLayer3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheLateralOlfactoryTractLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheLateralOlfactoryTractLayers13.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheLateralOlfactoryTractLayers13.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheLateralOlfactoryTractMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheLateralOlfactoryTractMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheLateralOlfactoryTractPyramidalLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheLateralOlfactoryTractPyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheOpticTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheOpticTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfThePosteriorCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfThePosteriorCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheSolitaryTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheSolitaryTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheSolitaryTractCentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheSolitaryTractCentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheSolitaryTractCommissuralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheSolitaryTractCommissuralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheSolitaryTractGelatinousPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheSolitaryTractGelatinousPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheSolitaryTractLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheSolitaryTractLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheSolitaryTractMedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheSolitaryTractMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheTrapezoidBody.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusOfTheTrapezoidBody.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusPrepositus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusPrepositus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusRapheMagnus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusRapheMagnus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusRapheObscurus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusRapheObscurus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusRaphePallidus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusRaphePallidus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusRaphePontis.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusRaphePontis.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusSagulum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusSagulum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusX.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusX.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusY.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusY.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusZ.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_nucleusZ.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_oculomotorNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_oculomotorNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_oculomotorNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_oculomotorNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_olfactoryAreas.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_olfactoryAreas.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_olfactoryNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_olfactoryNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_olfactoryNerveLayerOfMainOlfactoryBulb.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_olfactoryNerveLayerOfMainOlfactoryBulb.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_olfactoryTubercle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_olfactoryTubercle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_olfactoryTubercleLayers13.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_olfactoryTubercleLayers13.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_olfactoryTubercleMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_olfactoryTubercleMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_olfactoryTuberclePolymorphLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_olfactoryTuberclePolymorphLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_olfactoryTuberclePyramidalLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_olfactoryTuberclePyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_olivaryPretectalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_olivaryPretectalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_olivocerebellarTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_olivocerebellarTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_opticChiasm.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_opticChiasm.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_opticNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_opticNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_opticRadiation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_opticRadiation.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_opticTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_opticTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLateralPartLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLateralPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLateralPartLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLateralPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLateralPartLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLateralPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLateralPartLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLateralPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLateralPartLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLateralPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaMedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaMedialPartLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaMedialPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaMedialPartLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaMedialPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaMedialPartLayer2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaMedialPartLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaMedialPartLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaMedialPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaMedialPartLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaMedialPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaVentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaVentrolateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaVentrolateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaVentrolateralPartLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaVentrolateralPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaVentrolateralPartLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaVentrolateralPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaVentrolateralPartLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaVentrolateralPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaVentrolateralPartLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaVentrolateralPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaVentrolateralPartLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_orbitalAreaVentrolateralPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pallidotegmentalFascicle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pallidotegmentalFascicle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pallidothalmicPathway.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pallidothalmicPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pallidum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pallidum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pallidumCaudalRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pallidumCaudalRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pallidumDorsalRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pallidumDorsalRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pallidumMedialRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pallidumMedialRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pallidumVentralRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pallidumVentralRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabigeminalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabigeminalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleusLateralDivision.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleusLateralDivision.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleusLateralDivisionCentralLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleusLateralDivisionCentralLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleusLateralDivisionDorsalLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleusLateralDivisionDorsalLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleusLateralDivisionExternalLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleusLateralDivisionExternalLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleusLateralDivisionSuperiorLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleusLateralDivisionSuperiorLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleusLateralDivisionVentralLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleusLateralDivisionVentralLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleusMedialDivision.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleusMedialDivision.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleusMedialDivisionExternalMedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleusMedialDivisionExternalMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleusMedialDivisionMedialMedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleusMedialDivisionMedialMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleusMedialDivisionVentralMedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parabrachialNucleusMedialDivisionVentralMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paracentralNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paracentralNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parafascicularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parafascicularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parafloccularSulcus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parafloccularSulcus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraflocculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraflocculus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraflocculusGranularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraflocculusGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraflocculusMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraflocculusMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraflocculusPurkinjeLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraflocculusPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paragigantocellularReticularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paragigantocellularReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paragigantocellularReticularNucleusDorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paragigantocellularReticularNucleusDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paragigantocellularReticularNucleusLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paragigantocellularReticularNucleusLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paramedianLobule.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paramedianLobule.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paramedianLobuleGranularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paramedianLobuleGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paramedianLobuleMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paramedianLobuleMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paramedianLobulePurkinjeLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paramedianLobulePurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paramedianReticularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paramedianReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paramedianSulcus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paramedianSulcus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parapyramidalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parapyramidalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parapyramidalNucleusDeepPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parapyramidalNucleusDeepPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parapyramidalNucleusSuperficialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parapyramidalNucleusSuperficialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parasolitaryNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parasolitaryNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parastrialNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parastrialNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parasubiculum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parasubiculum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parasubiculumLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parasubiculumLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parasubiculumLayer2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parasubiculumLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parasubiculumLayer3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parasubiculumLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parasubthalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parasubthalamicNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parataenialNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parataenialNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusDescendingDivision.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusDescendingDivision.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusDescendingDivisionDorsalParvicellularPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusDescendingDivisionDorsalParvicellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusDescendingDivisionFornicealPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusDescendingDivisionFornicealPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusDescendingDivisionLateralParvicellularPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusDescendingDivisionLateralParvicellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusDescendingDivisionMedialParvicellularPartVentralZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusDescendingDivisionMedialParvicellularPartVentralZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusMagnocellularDivision.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusMagnocellularDivision.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusMagnocellularDivisionAnteriorMagnocellularPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusMagnocellularDivisionAnteriorMagnocellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusMagnocellularDivisionMedialMagnocellularPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusMagnocellularDivisionMedialMagnocellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusMagnocellularDivisionPosteriorMagnocellularPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusMagnocellularDivisionPosteriorMagnocellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusMagnocellularDivisionPosteriorMagnocellularPartLateralZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusMagnocellularDivisionPosteriorMagnocellularPartLateralZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusMagnocellularDivisionPosteriorMagnocellularPartMedialZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusMagnocellularDivisionPosteriorMagnocellularPartMedialZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusParvicellularDivision.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusParvicellularDivision.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusParvicellularDivisionAnteriorParvicellularPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusParvicellularDivisionAnteriorParvicellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusParvicellularDivisionMedialParvicellularPartDorsalZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusParvicellularDivisionMedialParvicellularPartDorsalZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusParvicellularDivisionPeriventricularPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularHypothalamicNucleusParvicellularDivisionPeriventricularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularNucleusOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_paraventricularNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parvicellularReticularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_parvicellularReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pedunculopontineNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pedunculopontineNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_perforantPath.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_perforantPath.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_periaqueductalGray.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_periaqueductalGray.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_perihypoglossalNuclei.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_perihypoglossalNuclei.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_peripeduncularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_peripeduncularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_perireunensisNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_perireunensisNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_perirhinalArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_perirhinalArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_perirhinalAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_perirhinalAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_perirhinalAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_perirhinalAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_perirhinalAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_perirhinalAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_perirhinalAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_perirhinalAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_perirhinalAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_perirhinalAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_periventricularBundleOfTheHypothalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_periventricularBundleOfTheHypothalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_periventricularBundleOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_periventricularBundleOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_periventricularHypothalamicNucleusAnteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_periventricularHypothalamicNucleusAnteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_periventricularHypothalamicNucleusIntermediatePart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_periventricularHypothalamicNucleusIntermediatePart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_periventricularHypothalamicNucleusPosteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_periventricularHypothalamicNucleusPosteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_periventricularHypothalamicNucleusPreopticPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_periventricularHypothalamicNucleusPreopticPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_periventricularRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_periventricularRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_periventricularZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_periventricularZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pinealBody.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pinealBody.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pinealStalk.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pinealStalk.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_piriformArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_piriformArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_piriformAreaLayers13.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_piriformAreaLayers13.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_piriformAreaMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_piriformAreaMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_piriformAreaPolymorphLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_piriformAreaPolymorphLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_piriformAreaPyramidalLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_piriformAreaPyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_piriformamygdalarArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_piriformamygdalarArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_piriformamygdalarAreaLayers13.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_piriformamygdalarAreaLayers13.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_piriformamygdalarAreaMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_piriformamygdalarAreaMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_piriformamygdalarAreaPolymorphLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_piriformamygdalarAreaPolymorphLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_piriformamygdalarAreaPyramidalLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_piriformamygdalarAreaPyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pons.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pons.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ponsBehavioralStateRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ponsBehavioralStateRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ponsMotorRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ponsMotorRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ponsSensoryRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ponsSensoryRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pontineCentralGray.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pontineCentralGray.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pontineGray.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pontineGray.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pontineReticularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pontineReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pontineReticularNucleusCaudalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pontineReticularNucleusCaudalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pontineReticularNucleusVentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pontineReticularNucleusVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postcommissuralFornix.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postcommissuralFornix.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorAmygdalarNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorAmygdalarNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorAuditoryArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorAuditoryArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorAuditoryAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorAuditoryAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorAuditoryAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorAuditoryAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorAuditoryAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorAuditoryAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorAuditoryAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorAuditoryAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorAuditoryAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorAuditoryAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorAuditoryAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorAuditoryAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorComplexOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorComplexOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorHypothalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorHypothalamicNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorLimitingNucleusOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorLimitingNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorParietalAssociationAreas.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorParietalAssociationAreas.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorParietalAssociationAreasLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorParietalAssociationAreasLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorParietalAssociationAreasLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorParietalAssociationAreasLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorParietalAssociationAreasLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorParietalAssociationAreasLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorParietalAssociationAreasLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorParietalAssociationAreasLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorParietalAssociationAreasLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorParietalAssociationAreasLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorParietalAssociationAreasLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorParietalAssociationAreasLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorPretectalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorPretectalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorSuperiorFissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteriorSuperiorFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posterodorsalPreopticNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posterodorsalPreopticNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posterolateralFissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posterolateralFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posterolateralVisualArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posterolateralVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posterolateralVisualAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posterolateralVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posterolateralVisualAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posterolateralVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posterolateralVisualAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posterolateralVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posterolateralVisualAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posterolateralVisualAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posterolateralVisualAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posterolateralVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posterolateralVisualAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posterolateralVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteromedialVisualArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteromedialVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteromedialVisualAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteromedialVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteromedialVisualAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteromedialVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteromedialVisualAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteromedialVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteromedialVisualAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteromedialVisualAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteromedialVisualAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteromedialVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteromedialVisualAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_posteromedialVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postpiriformTransitionArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postpiriformTransitionArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postpiriformTransitionAreaLayers1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postpiriformTransitionAreaLayers1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postpiriformTransitionAreaLayers13.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postpiriformTransitionAreaLayers13.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postpiriformTransitionAreaLayers2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postpiriformTransitionAreaLayers2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postpiriformTransitionAreaLayers3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postpiriformTransitionAreaLayers3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postrhinalArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postrhinalArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postrhinalAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postrhinalAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postrhinalAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postrhinalAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postrhinalAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postrhinalAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postrhinalAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postrhinalAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postrhinalAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postrhinalAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postrhinalAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postrhinalAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postsubiculum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postsubiculum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postsubiculumLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postsubiculumLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postsubiculumLayer2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postsubiculumLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postsubiculumLayer3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_postsubiculumLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_precentralFissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_precentralFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_precommissuralFornixDiagonalBand.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_precommissuralFornixDiagonalBand.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_precommissuralFornixGeneral.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_precommissuralFornixGeneral.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_precommissuralNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_precommissuralNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_preculminateFissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_preculminateFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prelimbicArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prelimbicArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prelimbicAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prelimbicAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prelimbicAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prelimbicAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prelimbicAreaLayer2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prelimbicAreaLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prelimbicAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prelimbicAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prelimbicAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prelimbicAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prelimbicAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prelimbicAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_premammillaryCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_premammillaryCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_preopticCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_preopticCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_preparasubthalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_preparasubthalamicNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prepyramidalFissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prepyramidalFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_presubiculum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_presubiculum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_presubiculumLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_presubiculumLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_presubiculumLayer2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_presubiculumLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_presubiculumLayer3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_presubiculumLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pretectalRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pretectalRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryAuditoryArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryAuditoryArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryAuditoryAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryAuditoryAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryAuditoryAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryAuditoryAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryAuditoryAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryAuditoryAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryAuditoryAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryAuditoryAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryAuditoryAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryAuditoryAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryAuditoryAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryAuditoryAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryFissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryMotorArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryMotorArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryMotorAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryMotorAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryMotorAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryMotorAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryMotorAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryMotorAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryMotorAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryMotorAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryMotorAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryMotorAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaBarrelField.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaBarrelField.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaBarrelFieldLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaBarrelFieldLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaBarrelFieldLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaBarrelFieldLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaBarrelFieldLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaBarrelFieldLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaBarrelFieldLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaBarrelFieldLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaBarrelFieldLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaBarrelFieldLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaBarrelFieldLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaBarrelFieldLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLowerLimb.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLowerLimb.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLowerLimbLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLowerLimbLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLowerLimbLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLowerLimbLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLowerLimbLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLowerLimbLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLowerLimbLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLowerLimbLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLowerLimbLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLowerLimbLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLowerLimbLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaLowerLimbLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaMouth.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaMouth.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaMouthLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaMouthLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaMouthLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaMouthLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaMouthLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaMouthLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaMouthLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaMouthLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaMouthLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaMouthLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaMouthLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaMouthLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaNose.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaNose.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaNoseLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaNoseLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaNoseLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaNoseLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaNoseLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaNoseLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaNoseLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaNoseLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaNoseLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaNoseLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaNoseLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaNoseLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaTrunk.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaTrunk.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaTrunkLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaTrunkLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaTrunkLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaTrunkLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaTrunkLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaTrunkLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaTrunkLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaTrunkLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaTrunkLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaTrunkLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaTrunkLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaTrunkLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUnassigned.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUnassigned.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUnassignedLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUnassignedLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUnassignedLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUnassignedLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUnassignedLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUnassignedLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUnassignedLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUnassignedLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUnassignedLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUnassignedLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUnassignedLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUnassignedLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUpperLimb.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUpperLimb.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUpperLimbLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUpperLimbLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUpperLimbLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUpperLimbLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUpperLimbLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUpperLimbLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUpperLimbLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUpperLimbLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUpperLimbLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUpperLimbLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUpperLimbLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primarySomatosensoryAreaUpperLimbLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryVisualArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryVisualAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryVisualAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryVisualAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryVisualAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryVisualAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryVisualAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryVisualAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_primaryVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_principalMammillaryTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_principalMammillaryTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_principalSensoryNucleusOfTheTrigeminal.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_principalSensoryNucleusOfTheTrigeminal.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_propriohypothalamicPathways.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_propriohypothalamicPathways.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_propriohypothalamicPathwaysDorsal.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_propriohypothalamicPathwaysDorsal.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_propriohypothalamicPathwaysLateral.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_propriohypothalamicPathwaysLateral.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_propriohypothalamicPathwaysMedial.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_propriohypothalamicPathwaysMedial.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_propriohypothalamicPathwaysVentral.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_propriohypothalamicPathwaysVentral.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prosubiculum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prosubiculum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prosubiculumDorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prosubiculumDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prosubiculumDorsalPartMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prosubiculumDorsalPartMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prosubiculumDorsalPartPyramidalLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prosubiculumDorsalPartPyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prosubiculumDorsalPartStratumRadiatum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prosubiculumDorsalPartStratumRadiatum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prosubiculumVentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prosubiculumVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prosubiculumVentralPartMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prosubiculumVentralPartMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prosubiculumVentralPartPyramidalLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prosubiculumVentralPartPyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prosubiculumVentralPartStratumRadiatum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_prosubiculumVentralPartStratumRadiatum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pyramid.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pyramid.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pyramidalDecussation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pyramidalDecussation.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pyramusVIII.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pyramusVIII.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pyramusVIIIGranularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pyramusVIIIGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pyramusVIIIMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pyramusVIIIMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pyramusVIIIPurkinjeLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_pyramusVIIIPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_redNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_redNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_reticularNucleusOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_reticularNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_reticulocerebellarTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_reticulocerebellarTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retina.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retina.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retriculospinalTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retriculospinalTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retriculospinalTractLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retriculospinalTractLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retriculospinalTractMedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retriculospinalTractMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrochiasmaticArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrochiasmaticArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrohippocampalRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrohippocampalRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaDorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaDorsalPartLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaDorsalPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaDorsalPartLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaDorsalPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaDorsalPartLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaDorsalPartLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaDorsalPartLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaDorsalPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaDorsalPartLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaDorsalPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaDorsalPartLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaDorsalPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaLateralAgranularPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaLateralAgranularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaLateralAgranularPartLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaLateralAgranularPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaLateralAgranularPartLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaLateralAgranularPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaLateralAgranularPartLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaLateralAgranularPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaLateralAgranularPartLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaLateralAgranularPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaLateralAgranularPartLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaLateralAgranularPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaVentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaVentralPartLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaVentralPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaVentralPartLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaVentralPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaVentralPartLayer2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaVentralPartLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaVentralPartLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaVentralPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaVentralPartLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaVentralPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaVentralPartLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_retrosplenialAreaVentralPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rhinalFissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rhinalFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rhinalIncisure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rhinalIncisure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rhinocele.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rhinocele.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rhomboidNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rhomboidNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_root.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_root.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostralLinearNucleusRaphe.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostralLinearNucleusRaphe.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralLateralVisualArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralLateralVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralLateralVisualAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralLateralVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralLateralVisualAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralLateralVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralLateralVisualAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralLateralVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralLateralVisualAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralLateralVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralLateralVisualAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralLateralVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralLateralVisualArealayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralLateralVisualArealayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralVisualArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rostrolateralVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rubroreticularTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rubroreticularTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rubrospinalTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_rubrospinalTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_secondaryFissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_secondaryFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_secondaryMotorArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_secondaryMotorArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_secondaryMotorAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_secondaryMotorAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_secondaryMotorAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_secondaryMotorAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_secondaryMotorAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_secondaryMotorAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_secondaryMotorAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_secondaryMotorAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_secondaryMotorAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_secondaryMotorAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_sensoryRootOfTheTrigeminalNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_sensoryRootOfTheTrigeminalNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_septofimbrialNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_septofimbrialNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_septohippocampalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_septohippocampalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_simpleFissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_simpleFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_simpleLobule.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_simpleLobule.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_simpleLobuleGranularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_simpleLobuleGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_simpleLobuleMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_simpleLobuleMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_simpleLobulePurkinjeLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_simpleLobulePurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_solitaryTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_solitaryTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatomotorAreas.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatomotorAreas.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatomotorAreasLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatomotorAreasLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatomotorAreasLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatomotorAreasLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatomotorAreasLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatomotorAreasLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatomotorAreasLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatomotorAreasLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatomotorAreasLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatomotorAreasLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatosensoryAreas.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatosensoryAreas.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatosensoryAreasLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatosensoryAreasLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatosensoryAreasLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatosensoryAreasLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatosensoryAreasLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatosensoryAreasLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatosensoryAreasLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatosensoryAreasLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatosensoryAreasLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatosensoryAreasLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatosensoryAreasLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_somatosensoryAreasLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinalNucleusOfTheTrigeminalCaudalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinalNucleusOfTheTrigeminalCaudalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinalNucleusOfTheTrigeminalInterpolarPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinalNucleusOfTheTrigeminalInterpolarPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinalNucleusOfTheTrigeminalOralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinalNucleusOfTheTrigeminalOralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinalNucleusOfTheTrigeminalOralPartCaudalDorsomedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinalNucleusOfTheTrigeminalOralPartCaudalDorsomedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinalNucleusOfTheTrigeminalOralPartMiddleDorsomedialPartDorsalZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinalNucleusOfTheTrigeminalOralPartMiddleDorsomedialPartDorsalZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinalNucleusOfTheTrigeminalOralPartMiddleDorsomedialPartVentralZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinalNucleusOfTheTrigeminalOralPartMiddleDorsomedialPartVentralZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinalNucleusOfTheTrigeminalOralPartRostralDorsomedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinalNucleusOfTheTrigeminalOralPartRostralDorsomedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinalNucleusOfTheTrigeminalOralPartVentrolateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinalNucleusOfTheTrigeminalOralPartVentrolateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinalTractOfTheTrigeminalNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinalTractOfTheTrigeminalNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinalVestibularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinalVestibularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinocerebellarTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinocerebellarTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinocervicalTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinocervicalTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinohypothalamicPathway.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinohypothalamicPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinoolivaryPathway.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinoolivaryPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinoreticularPathway.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinoreticularPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinotectalPathway.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinotectalPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinotelenchephalicPathway.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinotelenchephalicPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinothalamicTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinothalamicTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinovestibularPathway.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_spinovestibularPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_striaMedullaris.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_striaMedullaris.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_striaTerminalis.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_striaTerminalis.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_striatonigralPathway.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_striatonigralPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_striatum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_striatum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_striatumDorsalRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_striatumDorsalRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_striatumVentralRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_striatumVentralRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_striatumlikeAmygdalarNuclei.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_striatumlikeAmygdalarNuclei.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subceruleusNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subceruleusNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subependymalZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subependymalZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subfornicalOrgan.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subfornicalOrgan.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subgeniculateNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subgeniculateNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subiculum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subiculum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subiculumDorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subiculumDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subiculumDorsalPartMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subiculumDorsalPartMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subiculumDorsalPartPyramidalLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subiculumDorsalPartPyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subiculumDorsalPartStratumRadiatum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subiculumDorsalPartStratumRadiatum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subiculumVentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subiculumVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subiculumVentralPartMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subiculumVentralPartMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subiculumVentralPartPyramidalLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subiculumVentralPartPyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subiculumVentralPartStratumRadiatum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subiculumVentralPartStratumRadiatum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_sublaterodorsalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_sublaterodorsalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_submedialNucleusOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_submedialNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subparafascicularArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subparafascicularArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subparafascicularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subparafascicularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subparafascicularNucleusMagnocellularPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subparafascicularNucleusMagnocellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subparafascicularNucleusParvicellularPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subparafascicularNucleusParvicellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subparaventricularZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subparaventricularZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_substantiaInnominata.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_substantiaInnominata.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_substantiaNigraCompactPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_substantiaNigraCompactPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_substantiaNigraLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_substantiaNigraLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_substantiaNigraReticularPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_substantiaNigraReticularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subthalamicFascicle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subthalamicFascicle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subthalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_subthalamicNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorCentralNucleusRaphe.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorCentralNucleusRaphe.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorCentralNucleusRapheLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorCentralNucleusRapheLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorCentralNucleusRapheMedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorCentralNucleusRapheMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorCerebelarPeduncles.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorCerebelarPeduncles.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorCerebellarPeduncleDecussation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorCerebellarPeduncleDecussation.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusMotorRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusMotorRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusMotorRelatedDeepGrayLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusMotorRelatedDeepGrayLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusMotorRelatedDeepWhiteLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusMotorRelatedDeepWhiteLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusMotorRelatedIntermediateGrayLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusMotorRelatedIntermediateGrayLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusMotorRelatedIntermediateGrayLayerSublayerA.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusMotorRelatedIntermediateGrayLayerSublayerA.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusMotorRelatedIntermediateGrayLayerSublayerB.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusMotorRelatedIntermediateGrayLayerSublayerB.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusMotorRelatedIntermediateGrayLayerSublayerC.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusMotorRelatedIntermediateGrayLayerSublayerC.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusMotorRelatedIntermediateWhiteLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusMotorRelatedIntermediateWhiteLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusOpticLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusOpticLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusSensoryRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusSensoryRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusSuperficialGrayLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusSuperficialGrayLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusZonalLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorColliculusZonalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorOlivaryComplex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorOlivaryComplex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorOlivaryComplexLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorOlivaryComplexLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorOlivaryComplexMedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorOlivaryComplexMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorOlivaryComplexPeriolivaryRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorOlivaryComplexPeriolivaryRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorSalivatoryNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorSalivatoryNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorVestibularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_superiorVestibularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supplementalSomatosensoryArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supplementalSomatosensoryArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supplementalSomatosensoryAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supplementalSomatosensoryAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supplementalSomatosensoryAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supplementalSomatosensoryAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supplementalSomatosensoryAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supplementalSomatosensoryAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supplementalSomatosensoryAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supplementalSomatosensoryAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supplementalSomatosensoryAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supplementalSomatosensoryAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supplementalSomatosensoryAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supplementalSomatosensoryAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supracallosalCerebralWhiteMatter.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supracallosalCerebralWhiteMatter.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_suprachiasmaticNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_suprachiasmaticNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_suprachiasmaticPreopticNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_suprachiasmaticPreopticNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_suprageniculateNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_suprageniculateNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supragenualNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supragenualNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supramammillaryDecussation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supramammillaryDecussation.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supramammillaryNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supramammillaryNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supramammillaryNucleusLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supramammillaryNucleusLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supramammillaryNucleusMedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supramammillaryNucleusMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supraopticCommissures.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supraopticCommissures.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supraopticCommissuresAnterior.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supraopticCommissuresAnterior.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supraopticCommissuresDorsal.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supraopticCommissuresDorsal.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supraopticCommissuresVentral.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supraopticCommissuresVentral.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supraopticNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supraopticNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supratrigeminalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_supratrigeminalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTecta.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTecta.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaDorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaDorsalPartLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaDorsalPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaDorsalPartLayer2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaDorsalPartLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaDorsalPartLayer3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaDorsalPartLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaDorsalPartLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaDorsalPartLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaDorsalPartLayers14.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaDorsalPartLayers14.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaVentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaVentralPartLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaVentralPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaVentralPartLayer2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaVentralPartLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaVentralPartLayer3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaVentralPartLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaVentralPartLayers13.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_taeniaTectaVentralPartLayers13.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_tectospinalPathway.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_tectospinalPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_tectothalamicPathway.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_tectothalamicPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_tegmentalReticularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_tegmentalReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_temporalAssociationAreas.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_temporalAssociationAreas.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_temporalAssociationAreasLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_temporalAssociationAreasLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_temporalAssociationAreasLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_temporalAssociationAreasLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_temporalAssociationAreasLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_temporalAssociationAreasLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_temporalAssociationAreasLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_temporalAssociationAreasLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_temporalAssociationAreasLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_temporalAssociationAreasLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_temporalAssociationAreasLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_temporalAssociationAreasLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_terminalNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_terminalNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_thalamicPeduncles.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_thalamicPeduncles.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_thalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_thalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_thalamusPolymodalAssociationCortexRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_thalamusPolymodalAssociationCortexRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_thalamusRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_thalamusRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_thalamusSensorymotorCortexRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_thalamusSensorymotorCortexRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_thirdVentricle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_thirdVentricle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_trapezoidBody.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_trapezoidBody.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_triangularNucleusOfSeptum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_triangularNucleusOfSeptum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_trigeminalNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_trigeminalNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_trigeminocerebellarTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_trigeminocerebellarTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_trochlearNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_trochlearNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_trochlearNerveDecussation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_trochlearNerveDecussation.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_trochlearNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_trochlearNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_tuberalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_tuberalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_tuberomammillaryNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_tuberomammillaryNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_tuberomammillaryNucleusDorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_tuberomammillaryNucleusDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_tuberomammillaryNucleusVentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_tuberomammillaryNucleusVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_uncinateFascicle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_uncinateFascicle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_uvulaIX.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_uvulaIX.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_uvulaIXGranularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_uvulaIXGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_uvulaIXMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_uvulaIXMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_uvulaIXPurkinjeLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_uvulaIXPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_vagusNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_vagusNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_vascularOrganOfTheLaminaTerminalis.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_vascularOrganOfTheLaminaTerminalis.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralAnteriorlateralComplexOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralAnteriorlateralComplexOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralAuditoryArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralAuditoryArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralAuditoryAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralAuditoryAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralAuditoryAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralAuditoryAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralAuditoryAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralAuditoryAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralAuditoryAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralAuditoryAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralAuditoryAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralAuditoryAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralAuditoryAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralAuditoryAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralCochlearNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralCochlearNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralCommissureOfTheSpinalCord.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralCommissureOfTheSpinalCord.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralGroupOfTheDorsalThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralGroupOfTheDorsalThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralHippocampalCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralHippocampalCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralMedialNucleusOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralMedialNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralPartOfTheLateralGeniculateComplex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralPartOfTheLateralGeniculateComplex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralPartOfTheLateralGeniculateComplexLateralZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralPartOfTheLateralGeniculateComplexLateralZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralPartOfTheLateralGeniculateComplexMedialZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralPartOfTheLateralGeniculateComplexMedialZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralPosteriorComplexOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralPosteriorComplexOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralPosterolateralNucleusOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralPosterolateralNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralPosterolateralNucleusOfTheThalamusParvicellularPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralPosterolateralNucleusOfTheThalamusParvicellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralPosteromedialNucleusOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralPosteromedialNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralPosteromedialNucleusOfTheThalamusParvicellularPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralPosteromedialNucleusOfTheThalamusParvicellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralPremammillaryNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralPremammillaryNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralRoots.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralRoots.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralSpinocerebellarTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralSpinocerebellarTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralSpinothalamicTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralSpinothalamicTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralTegmentalArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralTegmentalArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralTegmentalDecussation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralTegmentalDecussation.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralTegmentalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventralTegmentalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventricularSystems.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventricularSystems.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventrolateralHypothalamicTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventrolateralHypothalamicTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventrolateralPreopticNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventrolateralPreopticNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventromedialHypothalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventromedialHypothalamicNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventromedialHypothalamicNucleusAnteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventromedialHypothalamicNucleusAnteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventromedialHypothalamicNucleusCentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventromedialHypothalamicNucleusCentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventromedialHypothalamicNucleusDorsomedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventromedialHypothalamicNucleusDorsomedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventromedialHypothalamicNucleusVentrolateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_ventromedialHypothalamicNucleusVentrolateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_vermalRegions.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_vermalRegions.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_vestibularNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_vestibularNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_vestibularNuclei.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_vestibularNuclei.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_vestibulocochlearNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_vestibulocochlearNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_vestibulospinalPathway.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_vestibulospinalPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visceralArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visceralArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visceralAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visceralAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visceralAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visceralAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visceralAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visceralAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visceralAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visceralAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visceralAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visceralAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visceralAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visceralAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visualAreas.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visualAreas.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visualAreasLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visualAreasLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visualAreasLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visualAreasLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visualAreasLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visualAreasLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visualAreasLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visualAreasLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visualAreasLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visualAreasLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visualAreasLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_visualAreasLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_vomeronasalNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_vomeronasalNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_zonaIncerta.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2015/AMBA_CCFv3-2015_zonaIncerta.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_abducensNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_abducensNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_abducensNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_abducensNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessoryAbducensNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessoryAbducensNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessoryFacialMotorNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessoryFacialMotorNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessoryOlfactoryBulb.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessoryOlfactoryBulb.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessoryOlfactoryBulbGlomerularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessoryOlfactoryBulbGlomerularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessoryOlfactoryBulbGranularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessoryOlfactoryBulbGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessoryOlfactoryBulbMitralLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessoryOlfactoryBulbMitralLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessoryOlfactoryTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessoryOlfactoryTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessoryOpticTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessoryOpticTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessorySpinalNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessorySpinalNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessorySupraopticGroup.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessorySupraopticGroup.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessoryTrigeminalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_accessoryTrigeminalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaDorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaDorsalPartLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaDorsalPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaDorsalPartLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaDorsalPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaDorsalPartLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaDorsalPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaDorsalPartLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaDorsalPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaDorsalPartLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaDorsalPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaPosteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaPosteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaPosteriorPartLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaPosteriorPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaPosteriorPartLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaPosteriorPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaPosteriorPartLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaPosteriorPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaPosteriorPartLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaPosteriorPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaPosteriorPartLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaPosteriorPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaVentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaVentralPartLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaVentralPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaVentralPartLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaVentralPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaVentralPartLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaVentralPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaVentralPartLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaVentralPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaVentralPartLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_agranularInsularAreaVentralPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_alveus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_alveus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ammonsHorn.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ammonsHorn.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_amygdalarCapsule.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_amygdalarCapsule.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_angularPath.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_angularPath.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ansaPeduncularis.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ansaPeduncularis.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ansiformLobule.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ansiformLobule.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ansoparamedianFissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ansoparamedianFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorAmygdalarArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorAmygdalarArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaDorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaDorsalPartLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaDorsalPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaDorsalPartLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaDorsalPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaDorsalPartLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaDorsalPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaDorsalPartLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaDorsalPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaDorsalPartLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaDorsalPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaVentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaVentralPart6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaVentralPart6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaVentralPart6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaVentralPart6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaVentralPartLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaVentralPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaVentralPartLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaVentralPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaVentralPartLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCingulateAreaVentralPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCommissureOlfactoryLimb.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCommissureOlfactoryLimb.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCommissureTemporalLimb.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorCommissureTemporalLimb.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorGroupOfTheDorsalThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorGroupOfTheDorsalThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorHypothalamicArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorHypothalamicArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorHypothalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorHypothalamicNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorHypothalamicNucleusAnteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorHypothalamicNucleusAnteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorHypothalamicNucleusCentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorHypothalamicNucleusCentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorHypothalamicNucleusDorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorHypothalamicNucleusDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorHypothalamicNucleusPosteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorHypothalamicNucleusPosteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorOlfactoryNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorOlfactoryNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorOlfactoryNucleusDorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorOlfactoryNucleusDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorOlfactoryNucleusExternalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorOlfactoryNucleusExternalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorOlfactoryNucleusLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorOlfactoryNucleusLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorOlfactoryNucleusLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorOlfactoryNucleusLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorOlfactoryNucleusLayer2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorOlfactoryNucleusLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorOlfactoryNucleusMedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorOlfactoryNucleusMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorOlfactoryNucleusPosteroventralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorOlfactoryNucleusPosteroventralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorPretectalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorPretectalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorTegmentalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteriorTegmentalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anterodorsalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anterodorsalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anterodorsalPreopticNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anterodorsalPreopticNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anterolateralVisualArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anterolateralVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anterolateralVisualAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anterolateralVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anterolateralVisualAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anterolateralVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anterolateralVisualAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anterolateralVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anterolateralVisualAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anterolateralVisualAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anterolateralVisualAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anterolateralVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anterolateralVisualAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anterolateralVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteromedialNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteromedialNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteromedialNucleusDorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteromedialNucleusDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteromedialNucleusVentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteromedialNucleusVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteromedialVisualArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteromedialVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteromedialVisualAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteromedialVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteromedialVisualAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteromedialVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteromedialVisualAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteromedialVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteromedialVisualAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteromedialVisualAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteromedialVisualAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteromedialVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteromedialVisualAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteromedialVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteroventralNucleusOfThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteroventralNucleusOfThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteroventralPeriventricularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteroventralPeriventricularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteroventralPreopticNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_anteroventralPreopticNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_arborVitae.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_arborVitae.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_arcuateHypothalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_arcuateHypothalamicNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_areaPostrema.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_areaPostrema.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_areaProstriata.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_areaProstriata.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_auditoryAreas.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_auditoryAreas.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_auditoryRadiation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_auditoryRadiation.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_barringtonsNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_barringtonsNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_basicCellGroupsAndRegions.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_basicCellGroupsAndRegions.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_basolateralAmygdalarNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_basolateralAmygdalarNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_basolateralAmygdalarNucleusAnteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_basolateralAmygdalarNucleusAnteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_basolateralAmygdalarNucleusPosteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_basolateralAmygdalarNucleusPosteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_basolateralAmygdalarNucleusVentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_basolateralAmygdalarNucleusVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_basomedialAmygdalarNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_basomedialAmygdalarNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_basomedialAmygdalarNucleusAnteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_basomedialAmygdalarNucleusAnteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_basomedialAmygdalarNucleusPosteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_basomedialAmygdalarNucleusPosteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalis.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalis.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisAnteriorDivision.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisAnteriorDivision.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisAnteriorDivisionAnterolateralArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisAnteriorDivisionAnterolateralArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisAnteriorDivisionAnteromedialArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisAnteriorDivisionAnteromedialArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisAnteriorDivisionDorsomedialNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisAnteriorDivisionDorsomedialNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisAnteriorDivisionFusiformNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisAnteriorDivisionFusiformNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisAnteriorDivisionJuxtacapsularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisAnteriorDivisionJuxtacapsularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisAnteriorDivisionMagnocellularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisAnteriorDivisionMagnocellularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisAnteriorDivisionOvalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisAnteriorDivisionOvalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisAnteriorDivisionRhomboidNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisAnteriorDivisionRhomboidNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisAnteriorDivisionVentralNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisAnteriorDivisionVentralNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisPosteriorDivision.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisPosteriorDivision.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisPosteriorDivisionDorsalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisPosteriorDivisionDorsalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisPosteriorDivisionInterfascicularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisPosteriorDivisionInterfascicularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisPosteriorDivisionPrincipalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisPosteriorDivisionPrincipalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisPosteriorDivisionStrialExtension.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisPosteriorDivisionStrialExtension.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisPosteriorDivisionTransverseNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleiOfTheStriaTerminalisPosteriorDivisionTransverseNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleusOfTheAccessoryOlfactoryTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleusOfTheAccessoryOlfactoryTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleusOfTheAnteriorCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bedNucleusOfTheAnteriorCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_brachiumOfTheInferiorColliculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_brachiumOfTheInferiorColliculus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_brachiumOfTheSuperiorColliculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_brachiumOfTheSuperiorColliculus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_brainStem.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_brainStem.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bulbocerebellarTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_bulbocerebellarTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_caudoputamen.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_caudoputamen.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_centralAmygdalarNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_centralAmygdalarNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_centralAmygdalarNucleusCapsularPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_centralAmygdalarNucleusCapsularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_centralAmygdalarNucleusLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_centralAmygdalarNucleusLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_centralAmygdalarNucleusMedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_centralAmygdalarNucleusMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_centralCanalSpinalCordmedulla.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_centralCanalSpinalCordmedulla.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_centralLateralNucleusOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_centralLateralNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_centralLinearNucleusRaphe.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_centralLinearNucleusRaphe.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_centralLobule.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_centralLobule.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_centralMedialNucleusOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_centralMedialNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_centralTegmentalBundle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_centralTegmentalBundle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebalPeduncle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebalPeduncle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebellarCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebellarCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebellarCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebellarCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebellarCortexGranularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebellarCortexGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebellarCortexMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebellarCortexMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebellarCortexPurkinjeLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebellarCortexPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebellarNuclei.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebellarNuclei.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebellarPeduncles.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebellarPeduncles.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebellum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebellum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebellumRelatedFiberTracts.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebellumRelatedFiberTracts.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebralAqueduct.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebralAqueduct.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebralCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebralCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebralNuclei.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebralNuclei.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebralNucleiRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebralNucleiRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebrum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebrum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebrumRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cerebrumRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cervicothalamicTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cervicothalamicTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_choroidFissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_choroidFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_choroidPlexus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_choroidPlexus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cingulumBundle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cingulumBundle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_claustrum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_claustrum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cochlearNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cochlearNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cochlearNuclei.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cochlearNuclei.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cochlearNucleusSubpedunclularGranularRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cochlearNucleusSubpedunclularGranularRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_columnsOfTheFornix.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_columnsOfTheFornix.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_commissuralBranchOfStriaTerminalis.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_commissuralBranchOfStriaTerminalis.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_copulaPyramidis.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_copulaPyramidis.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_copulaPyramidisGranularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_copulaPyramidisGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_copulaPyramidisMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_copulaPyramidisMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_copulaPyramidisPurkinjeLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_copulaPyramidisPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corpusCallosum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corpusCallosum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corpusCallosumAnteriorForceps.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corpusCallosumAnteriorForceps.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corpusCallosumBody.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corpusCallosumBody.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corpusCallosumExtremeCapsule.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corpusCallosumExtremeCapsule.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corpusCallosumPosteriorForceps.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corpusCallosumPosteriorForceps.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corpusCallosumRostrum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corpusCallosumRostrum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corpusCallosumSplenium.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corpusCallosumSplenium.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaAnteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaAnteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaAnteriorPartLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaAnteriorPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaAnteriorPartLayer2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaAnteriorPartLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaAnteriorPartLayer3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaAnteriorPartLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartLateralZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartLateralZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartLateralZoneLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartLateralZoneLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartLateralZoneLayer2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartLateralZoneLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartLateralZoneLayer3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartLateralZoneLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartLateralZoneLayers12.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartLateralZoneLayers12.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartLateralZoneLayers13.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartLateralZoneLayers13.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartMedialZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartMedialZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartMedialZoneLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartMedialZoneLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartMedialZoneLayer2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartMedialZoneLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartMedialZoneLayer3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartMedialZoneLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartMedialZoneLayers12.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartMedialZoneLayers12.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartMedialZoneLayers13.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalAmygdalarAreaPosteriorPartMedialZoneLayers13.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalPlate.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalPlate.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalSubplate.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticalSubplate.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticobulbarTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticobulbarTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticopontineTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticopontineTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticorubralTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticorubralTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticospinalTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticospinalTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticospinalTractCrossed.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticospinalTractCrossed.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticospinalTractUncrossed.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticospinalTractUncrossed.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticotectalTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_corticotectalTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cranialNerves.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cranialNerves.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_crossedTectospinalPathway.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_crossedTectospinalPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_crus1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_crus1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_crus1GranularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_crus1GranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_crus1MolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_crus1MolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_crus1PurkinjeLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_crus1PurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_crus2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_crus2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_crus2GranularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_crus2GranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_crus2MolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_crus2MolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_crus2PurkinjeLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_crus2PurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_culmen.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_culmen.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cuneateFascicle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cuneateFascicle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cuneateNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cuneateNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cuneiformNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cuneiformNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cuneocerebellarTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_cuneocerebellarTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_decliveVI.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_decliveVI.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_decliveVIGranularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_decliveVIGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_decliveVIMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_decliveVIMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_decliveVIPurkinjeLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_decliveVIPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusCrest.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusCrest.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusCrestGranuleCellLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusCrestGranuleCellLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusCrestMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusCrestMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusCrestPolymorphLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusCrestPolymorphLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusGranuleCellLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusGranuleCellLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusLateralBlade.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusLateralBlade.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusLateralBladeGranuleCellLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusLateralBladeGranuleCellLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusLateralBladeMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusLateralBladeMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusLateralBladePolymorphLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusLateralBladePolymorphLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusMedialBlade.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusMedialBlade.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusMedialBladeGranuleCellLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusMedialBladeGranuleCellLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusMedialBladeMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusMedialBladeMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusMedialBladePolymorphLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusMedialBladePolymorphLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusPolymorphLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusPolymorphLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusSubgranularZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateGyrusSubgranularZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dentateNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_diagonalBandNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_diagonalBandNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_directTectospinalPathway.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_directTectospinalPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dopaminergicA13Group.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dopaminergicA13Group.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_doralTegmentalDecussation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_doralTegmentalDecussation.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalAcousticStria.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalAcousticStria.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalAuditoryArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalAuditoryArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalAuditoryAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalAuditoryAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalAuditoryAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalAuditoryAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalAuditoryAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalAuditoryAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalAuditoryAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalAuditoryAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalAuditoryAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalAuditoryAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalAuditoryAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalAuditoryAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalCochlearNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalCochlearNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalColumn.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalColumn.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalColumnNuclei.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalColumnNuclei.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalCommissureOfTheSpinalCord.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalCommissureOfTheSpinalCord.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalFornix.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalFornix.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalHippocampalCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalHippocampalCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalLimb.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalLimb.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalLongitudinalFascicle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalLongitudinalFascicle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalMotorNucleusOfTheVagusNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalMotorNucleusOfTheVagusNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalNucleusRaphe.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalNucleusRaphe.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPartOfTheLateralGeniculateComplex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPartOfTheLateralGeniculateComplex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPartOfTheLateralGeniculateComplexCore.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPartOfTheLateralGeniculateComplexCore.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPartOfTheLateralGeniculateComplexIpsilateralZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPartOfTheLateralGeniculateComplexIpsilateralZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPartOfTheLateralGeniculateComplexShell.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPartOfTheLateralGeniculateComplexShell.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPeduncularArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPeduncularArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPeduncularAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPeduncularAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPeduncularAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPeduncularAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPeduncularAreaLayer2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPeduncularAreaLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPeduncularAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPeduncularAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPeduncularAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPeduncularAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPremammillaryNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalPremammillaryNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalRoots.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalRoots.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalSpinocerebellarTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalSpinocerebellarTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalTegmentalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalTegmentalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalTegmentalTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalTegmentalTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalTerminalNucleusOfTheAccessoryOpticTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalTerminalNucleusOfTheAccessoryOpticTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalThalamusRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsalThalamusRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsolateralFascicle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsolateralFascicle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsomedialNucleusOfTheHypothalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsomedialNucleusOfTheHypothalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsomedialNucleusOfTheHypothalamusAnteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsomedialNucleusOfTheHypothalamusAnteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsomedialNucleusOfTheHypothalamusPosteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsomedialNucleusOfTheHypothalamusPosteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsomedialNucleusOfTheHypothalamusVentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_dorsomedialNucleusOfTheHypothalamusVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ectorhinalArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ectorhinalArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ectorhinalAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ectorhinalAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ectorhinalAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ectorhinalAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ectorhinalAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ectorhinalAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ectorhinalAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ectorhinalAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ectorhinalAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ectorhinalAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_edingerWestphalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_edingerWestphalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_efferentCochlearGroup.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_efferentCochlearGroup.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_efferentCochleovestibularBundle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_efferentCochleovestibularBundle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_efferentVestibularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_efferentVestibularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_endopiriformNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_endopiriformNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_endopiriformNucleusDorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_endopiriformNucleusDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_endopiriformNucleusVentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_endopiriformNucleusVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_endorhinalGroove.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_endorhinalGroove.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer2a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer2a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer2b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer2b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer4-5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer4-5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer5-6.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer5-6.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaLateralPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartDorsalZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartDorsalZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartDorsalZoneLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartDorsalZoneLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartDorsalZoneLayer2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartDorsalZoneLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartDorsalZoneLayer2a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartDorsalZoneLayer2a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartDorsalZoneLayer2b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartDorsalZoneLayer2b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartDorsalZoneLayer3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartDorsalZoneLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartDorsalZoneLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartDorsalZoneLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartDorsalZoneLayer5-6.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartDorsalZoneLayer5-6.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartDorsalZoneLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartDorsalZoneLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartDorsalZoneLayer6.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartDorsalZoneLayer6.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartVentralZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartVentralZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartVentralZoneLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartVentralZoneLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartVentralZoneLayer2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartVentralZoneLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartVentralZoneLayer3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartVentralZoneLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartVentralZoneLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartVentralZoneLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartVentralZoneLayer5-6.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_entorhinalAreaMedialPartVentralZoneLayer5-6.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_epithalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_epithalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_epithalamusRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_epithalamusRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ethmoidNucleusOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ethmoidNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_externalCapsule.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_externalCapsule.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_externalCuneateNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_externalCuneateNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_externalMedullaryLaminaOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_externalMedullaryLaminaOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_extrapyramidalFiberSystems.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_extrapyramidalFiberSystems.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_facialMotorNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_facialMotorNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_facialNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_facialNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fasciculusProprius.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fasciculusProprius.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fasciculusRetroflexus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fasciculusRetroflexus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fasciolaCinerea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fasciolaCinerea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fastigialNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fastigialNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fiberTracts.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fiberTracts.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA1PyramidalLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA1PyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA1StratumLacunosummoleculare.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA1StratumLacunosummoleculare.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA1StratumOriens.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA1StratumOriens.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA1StratumRadiatum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA1StratumRadiatum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA2PyramidalLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA2PyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA2StratumLacunosummoleculare.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA2StratumLacunosummoleculare.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA2StratumOriens.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA2StratumOriens.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA2StratumRadiatum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA2StratumRadiatum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA3PyramidalLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA3PyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA3StratumLacunosummoleculare.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA3StratumLacunosummoleculare.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA3StratumLucidum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA3StratumLucidum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA3StratumOriens.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA3StratumOriens.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA3StratumRadiatum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldCA3StratumRadiatum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldsOfForel.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fieldsOfForel.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fimbria.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fimbria.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_flocculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_flocculus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_flocculusGranularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_flocculusGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_flocculusMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_flocculusMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_flocculusPurkinjeLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_flocculusPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_foliumtuberVermisVII.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_foliumtuberVermisVII.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_foliumtuberVermisVIIGranularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_foliumtuberVermisVIIGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_foliumtuberVermisVIIMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_foliumtuberVermisVIIMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_foliumtuberVermisVIIPurkinjeLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_foliumtuberVermisVIIPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fornixSystem.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fornixSystem.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fourthVentricle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fourthVentricle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_frontalPoleCerebralCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_frontalPoleCerebralCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_frontalPoleLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_frontalPoleLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_frontalPoleLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_frontalPoleLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_frontalPoleLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_frontalPoleLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_frontalPoleLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_frontalPoleLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_frontalPoleLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_frontalPoleLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fundusOfStriatum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_fundusOfStriatum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_geniculateGroupDorsalThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_geniculateGroupDorsalThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_geniculateGroupVentralThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_geniculateGroupVentralThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_genuOfCorpusCallosum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_genuOfCorpusCallosum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_genuOfTheFacialNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_genuOfTheFacialNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_gigantocellularReticularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_gigantocellularReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_globusPallidusExternalSegment.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_globusPallidusExternalSegment.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_globusPallidusInternalSegment.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_globusPallidusInternalSegment.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_glossopharyngealNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_glossopharyngealNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_gracileFascicle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_gracileFascicle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_gracileNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_gracileNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_granularLaminaOfTheCochlearNuclei.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_granularLaminaOfTheCochlearNuclei.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_grooves.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_grooves.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_groovesOfTheCerebellarCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_groovesOfTheCerebellarCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_groovesOfTheCerebralCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_groovesOfTheCerebralCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_gustatoryAreas.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_gustatoryAreas.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_gustatoryAreasLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_gustatoryAreasLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_gustatoryAreasLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_gustatoryAreasLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_gustatoryAreasLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_gustatoryAreasLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_gustatoryAreasLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_gustatoryAreasLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_gustatoryAreasLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_gustatoryAreasLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_gustatoryAreasLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_gustatoryAreasLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_habenularCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_habenularCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hemisphericRegions.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hemisphericRegions.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hindbrain.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hindbrain.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hippocampalCommissures.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hippocampalCommissures.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hippocampalFissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hippocampalFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hippocampalFormation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hippocampalFormation.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hippocampalRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hippocampalRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hippocampoamygdalarTransitionArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hippocampoamygdalarTransitionArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hypoglossalNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hypoglossalNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hypoglossalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hypoglossalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hypothalamicLateralZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hypothalamicLateralZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hypothalamicMedialZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hypothalamicMedialZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hypothalamohypophysialTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hypothalamohypophysialTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hypothalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hypothalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hypothalamusRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_hypothalamusRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_induseumGriseum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_induseumGriseum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_inferiorCerebellarPeduncle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_inferiorCerebellarPeduncle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_inferiorColliculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_inferiorColliculus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_inferiorColliculusCentralNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_inferiorColliculusCentralNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_inferiorColliculusCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_inferiorColliculusCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_inferiorColliculusDorsalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_inferiorColliculusDorsalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_inferiorColliculusExternalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_inferiorColliculusExternalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_inferiorOlivaryComplex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_inferiorOlivaryComplex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_inferiorSalivatoryNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_inferiorSalivatoryNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_infracerebellarNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_infracerebellarNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_infralimbicArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_infralimbicArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_infralimbicAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_infralimbicAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_infralimbicAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_infralimbicAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_infralimbicAreaLayer2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_infralimbicAreaLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_infralimbicAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_infralimbicAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_infralimbicAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_infralimbicAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_infralimbicAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_infralimbicAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interanterodorsalNucleusOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interanterodorsalNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interanteromedialNucleusOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interanteromedialNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interbrain.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interbrain.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intercalatedAmygdalarNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intercalatedAmygdalarNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intercollicularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intercollicularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intercruralFissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intercruralFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interfascicularNucleusRaphe.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interfascicularNucleusRaphe.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intergeniculateLeafletOfTheLateralGeniculateComplex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intergeniculateLeafletOfTheLateralGeniculateComplex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intermediateAcousticStria.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intermediateAcousticStria.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intermediateGeniculateNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intermediateGeniculateNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intermediateNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intermediateNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intermediateReticularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intermediateReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intermediodorsalNucleusOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intermediodorsalNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_internalArcuateFibers.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_internalArcuateFibers.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_internalCapsule.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_internalCapsule.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_internalMedullaryLaminaOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_internalMedullaryLaminaOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interpeduncularFossa.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interpeduncularFossa.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interpeduncularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interpeduncularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interpeduncularNucleusApical.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interpeduncularNucleusApical.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interpeduncularNucleusCaudal.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interpeduncularNucleusCaudal.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interpeduncularNucleusDorsolateral.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interpeduncularNucleusDorsolateral.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interpeduncularNucleusDorsomedial.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interpeduncularNucleusDorsomedial.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interpeduncularNucleusIntermediate.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interpeduncularNucleusIntermediate.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interpeduncularNucleusLateral.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interpeduncularNucleusLateral.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interpeduncularNucleusRostral.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interpeduncularNucleusRostral.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interpeduncularNucleusRostrolateral.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interpeduncularNucleusRostrolateral.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interposedNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interposedNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interstitialNucleusOfCajal.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interstitialNucleusOfCajal.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interstitialNucleusOfTheVestibularNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interstitialNucleusOfTheVestibularNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intertrigeminalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intertrigeminalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interventricularForamen.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_interventricularForamen.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intralaminarNucleiOfTheDorsalThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intralaminarNucleiOfTheDorsalThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intraparafloccularFissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_intraparafloccularFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_islandsOfCalleja.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_islandsOfCalleja.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_isocortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_isocortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_juxtarestiformBody.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_juxtarestiformBody.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_koellikerFuseSubnucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_koellikerFuseSubnucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralAmygdalarNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralAmygdalarNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralDorsalNucleusOfThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralDorsalNucleusOfThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralForebrainBundleSystem.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralForebrainBundleSystem.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralGroupOfTheDorsalThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralGroupOfTheDorsalThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralHabenula.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralHabenula.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralHypothalamicArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralHypothalamicArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralLemniscus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralLemniscus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralMammillaryNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralMammillaryNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralOlfactoryTractBody.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralOlfactoryTractBody.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralOlfactoryTractGeneral.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralOlfactoryTractGeneral.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralPosteriorNucleusOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralPosteriorNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralPreopticArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralPreopticArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralRecess.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralRecess.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralReticularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralReticularNucleusMagnocellularPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralReticularNucleusMagnocellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralReticularNucleusParvicellularPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralReticularNucleusParvicellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralSeptalComplex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralSeptalComplex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralSeptalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralSeptalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralSeptalNucleusCaudalCaudodorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralSeptalNucleusCaudalCaudodorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralSeptalNucleusRostralRostroventralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralSeptalNucleusRostralRostroventralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralSeptalNucleusVentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralSeptalNucleusVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralSpinothalamicTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralSpinothalamicTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralStripOfStriatum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralStripOfStriatum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralTegmentalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralTegmentalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralTerminalNucleusOfTheAccessoryOpticTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralTerminalNucleusOfTheAccessoryOpticTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralVentricle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralVentricle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralVestibularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralVestibularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralVisualArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralVisualAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralVisualAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralVisualAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralVisualAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralVisualAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralVisualAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralVisualAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lateralVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterodorsalTegmentalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterodorsalTegmentalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterointermediateArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterointermediateArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterointermediateAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterointermediateAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterointermediateAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterointermediateAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterointermediateAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterointermediateAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterointermediateAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterointermediateAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterointermediateAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterointermediateAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterointermediateAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterointermediateAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterolateralAnteriorVisualArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterolateralAnteriorVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterolateralAnteriorVisualAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterolateralAnteriorVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterolateralAnteriorVisualAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterolateralAnteriorVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterolateralAnteriorVisualAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterolateralAnteriorVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterolateralAnteriorVisualAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterolateralAnteriorVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterolateralAnteriorVisualAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterolateralAnteriorVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterolateralAnteriorVisualArealayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_laterolateralAnteriorVisualArealayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_layer6bIsocortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_layer6bIsocortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_linearNucleusOfTheMedulla.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_linearNucleusOfTheMedulla.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lingulaI.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lingulaI.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lingulaIGranularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lingulaIGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lingulaIMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lingulaIMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lingulaIPurkinjeLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lingulaIPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleII.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleII.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIIGranularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIIGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIII.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIII.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIIIGranularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIIIGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIIIMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIIIMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIIIPurkinjeLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIIIPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIIMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIIMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIIPurkinjeLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIIPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIV.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIV.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIVGranularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIVGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIVMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIVMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIVPurkinjeLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleIVPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleV.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleV.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleVGranularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleVGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleVMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleVMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleVPurkinjeLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobuleVPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobulesIV-V.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobulesIV-V.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobulesIV-VGranularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobulesIV-VGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobulesIV-VMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobulesIV-VMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobulesIV-VPurkinjeLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_lobulesIV-VPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_locusCeruleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_locusCeruleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_longitudinalAssociationBundle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_longitudinalAssociationBundle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_magnocellularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_magnocellularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_magnocellularReticularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_magnocellularReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mainOlfactoryBulb.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mainOlfactoryBulb.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mainOlfactoryBulbGlomerularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mainOlfactoryBulbGlomerularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mainOlfactoryBulbGranuleLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mainOlfactoryBulbGranuleLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mainOlfactoryBulbInnerPlexiformLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mainOlfactoryBulbInnerPlexiformLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mainOlfactoryBulbMitralLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mainOlfactoryBulbMitralLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mainOlfactoryBulbOuterPlexiformLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mainOlfactoryBulbOuterPlexiformLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_majorIslandOfCalleja.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_majorIslandOfCalleja.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mammillaryBody.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mammillaryBody.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mammillaryPeduncle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mammillaryPeduncle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mammillaryRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mammillaryRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mammillotegmentalTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mammillotegmentalTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mammillothalamicTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mammillothalamicTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialAccesoryOculomotorNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialAccesoryOculomotorNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialAmygdalarNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialAmygdalarNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialAmygdalarNucleusAnterodorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialAmygdalarNucleusAnterodorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialAmygdalarNucleusAnteroventralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialAmygdalarNucleusAnteroventralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialAmygdalarNucleusPosterodorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialAmygdalarNucleusPosterodorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialAmygdalarNucleusPosterodorsalPartSublayerA.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialAmygdalarNucleusPosterodorsalPartSublayerA.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialAmygdalarNucleusPosterodorsalPartSublayerB.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialAmygdalarNucleusPosterodorsalPartSublayerB.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialAmygdalarNucleusPosterodorsalPartSublayerC.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialAmygdalarNucleusPosterodorsalPartSublayerC.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialAmygdalarNucleusPosteroventralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialAmygdalarNucleusPosteroventralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialCorticohypothalamicTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialCorticohypothalamicTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialForebrainBundle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialForebrainBundle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialForebrainBundleSystem.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialForebrainBundleSystem.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialGeniculateComplex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialGeniculateComplex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialGeniculateComplexDorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialGeniculateComplexDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialGeniculateComplexMedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialGeniculateComplexMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialGeniculateComplexVentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialGeniculateComplexVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialGroupOfTheDorsalThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialGroupOfTheDorsalThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialHabenula.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialHabenula.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialLemniscus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialLemniscus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialLongitudinalFascicle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialLongitudinalFascicle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialMammillaryNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialMammillaryNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialMammillaryNucleusDorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialMammillaryNucleusDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialMammillaryNucleusLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialMammillaryNucleusLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialMammillaryNucleusMedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialMammillaryNucleusMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialMammillaryNucleusMedianPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialMammillaryNucleusMedianPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialMammillaryNucleusPosteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialMammillaryNucleusPosteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialPreopticArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialPreopticArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialPreopticNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialPreopticNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialPreopticNucleusCentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialPreopticNucleusCentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialPreopticNucleusLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialPreopticNucleusLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialPreopticNucleusMedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialPreopticNucleusMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialPretectalArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialPretectalArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialSeptalComplex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialSeptalComplex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialSeptalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialSeptalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialTerminalNucleusOfTheAccessoryOpticTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialTerminalNucleusOfTheAccessoryOpticTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialVestibularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialVestibularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialVisualArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialVisualAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialVisualAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialVisualAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialVisualAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialVisualAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialVisualArealayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medialVisualArealayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medianEminence.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medianEminence.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medianPreopticNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medianPreopticNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediodorsalNucleusOfThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediodorsalNucleusOfThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediodorsalNucleusOfTheThalamusCentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediodorsalNucleusOfTheThalamusCentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediodorsalNucleusOfTheThalamusLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediodorsalNucleusOfTheThalamusLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediodorsalNucleusOfTheThalamusMedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediodorsalNucleusOfTheThalamusMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialAnteriorVisualArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialAnteriorVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialAnteriorVisualAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialAnteriorVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialAnteriorVisualAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialAnteriorVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialAnteriorVisualAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialAnteriorVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialAnteriorVisualAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialAnteriorVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialAnteriorVisualAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialAnteriorVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialAnteriorVisualArealayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialAnteriorVisualArealayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialPosteriorVisualArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialPosteriorVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialPosteriorVisualAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialPosteriorVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialPosteriorVisualAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialPosteriorVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialPosteriorVisualAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialPosteriorVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialPosteriorVisualAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialPosteriorVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialPosteriorVisualAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialPosteriorVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialPosteriorVisualArealayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_mediomedialPosteriorVisualArealayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medulla.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medulla.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medullaBehavioralStateRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medullaBehavioralStateRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medullaMotorRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medullaMotorRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medullaSensoryRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medullaSensoryRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medullaryReticularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medullaryReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medullaryReticularNucleusDorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medullaryReticularNucleusDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medullaryReticularNucleusVentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_medullaryReticularNucleusVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrain.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrain.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainBehavioralStateRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainBehavioralStateRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainMotorRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainMotorRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainRapheNuclei.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainRapheNuclei.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainReticularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainReticularNucleusMagnocellularPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainReticularNucleusMagnocellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainReticularNucleusMagnocellularPartGeneral.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainReticularNucleusMagnocellularPartGeneral.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainReticularNucleusParvicellularPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainReticularNucleusParvicellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainReticularNucleusRetrorubralArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainReticularNucleusRetrorubralArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainSensoryRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainSensoryRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainTractOfTheTrigeminalNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainTractOfTheTrigeminalNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainTrigeminalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midbrainTrigeminalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_middleCerebellarPeduncle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_middleCerebellarPeduncle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_middleThalamicCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_middleThalamicCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midlineGroupOfTheDorsalThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_midlineGroupOfTheDorsalThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_motorNucleusOfTrigeminal.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_motorNucleusOfTrigeminal.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_motorRootOfTheTrigeminalNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_motorRootOfTheTrigeminalNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nigrostriatalTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nigrostriatalTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nigrothalamicFibers.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nigrothalamicFibers.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nodularFissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nodularFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nodulusX.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nodulusX.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nodulusXGranularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nodulusXGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nodulusXMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nodulusXMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nodulusXPurkinjeLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nodulusXPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusAccumbens.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusAccumbens.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusAmbiguus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusAmbiguus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusAmbiguusDorsalDivision.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusAmbiguusDorsalDivision.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusAmbiguusVentralDivision.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusAmbiguusVentralDivision.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusCircularis.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusCircularis.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusIncertus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusIncertus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusIntercalatus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusIntercalatus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfDarkschewitsch.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfDarkschewitsch.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfReuniens.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfReuniens.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfRoller.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfRoller.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheBrachiumOfTheInferiorColliculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheBrachiumOfTheInferiorColliculus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheLateralLemniscus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheLateralLemniscus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheLateralLemniscusDorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheLateralLemniscusDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheLateralLemniscusHorizontalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheLateralLemniscusHorizontalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheLateralLemniscusVentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheLateralLemniscusVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheLateralOlfactoryTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheLateralOlfactoryTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheLateralOlfactoryTractLayer3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheLateralOlfactoryTractLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheLateralOlfactoryTractLayers13.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheLateralOlfactoryTractLayers13.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheLateralOlfactoryTractMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheLateralOlfactoryTractMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheLateralOlfactoryTractPyramidalLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheLateralOlfactoryTractPyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheOpticTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheOpticTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfThePosteriorCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfThePosteriorCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheSolitaryTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheSolitaryTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheSolitaryTractCentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheSolitaryTractCentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheSolitaryTractCommissuralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheSolitaryTractCommissuralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheSolitaryTractGelatinousPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheSolitaryTractGelatinousPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheSolitaryTractLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheSolitaryTractLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheSolitaryTractMedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheSolitaryTractMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheTrapezoidBody.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusOfTheTrapezoidBody.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusPrepositus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusPrepositus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusRapheMagnus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusRapheMagnus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusRapheObscurus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusRapheObscurus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusRaphePallidus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusRaphePallidus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusRaphePontis.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusRaphePontis.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusSagulum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusSagulum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusX.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusX.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusY.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusY.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusZ.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_nucleusZ.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_oculomotorNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_oculomotorNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_oculomotorNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_oculomotorNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_olfactoryAreas.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_olfactoryAreas.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_olfactoryNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_olfactoryNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_olfactoryNerveLayerOfMainOlfactoryBulb.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_olfactoryNerveLayerOfMainOlfactoryBulb.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_olfactoryTubercle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_olfactoryTubercle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_olfactoryTubercleLayers13.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_olfactoryTubercleLayers13.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_olfactoryTubercleMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_olfactoryTubercleMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_olfactoryTuberclePolymorphLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_olfactoryTuberclePolymorphLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_olfactoryTuberclePyramidalLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_olfactoryTuberclePyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_olivaryPretectalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_olivaryPretectalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_olivocerebellarTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_olivocerebellarTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_opticChiasm.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_opticChiasm.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_opticNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_opticNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_opticRadiation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_opticRadiation.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_opticTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_opticTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLateralPartLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLateralPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLateralPartLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLateralPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLateralPartLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLateralPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLateralPartLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLateralPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLateralPartLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLateralPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaMedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaMedialPartLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaMedialPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaMedialPartLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaMedialPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaMedialPartLayer2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaMedialPartLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaMedialPartLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaMedialPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaMedialPartLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaMedialPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaMedialPartLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaMedialPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaVentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaVentrolateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaVentrolateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaVentrolateralPartLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaVentrolateralPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaVentrolateralPartLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaVentrolateralPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaVentrolateralPartLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaVentrolateralPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaVentrolateralPartLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaVentrolateralPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaVentrolateralPartLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_orbitalAreaVentrolateralPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pallidotegmentalFascicle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pallidotegmentalFascicle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pallidothalamicPathway.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pallidothalamicPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pallidum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pallidum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pallidumCaudalRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pallidumCaudalRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pallidumDorsalRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pallidumDorsalRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pallidumMedialRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pallidumMedialRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pallidumVentralRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pallidumVentralRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabigeminalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabigeminalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleusLateralDivision.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleusLateralDivision.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleusLateralDivisionCentralLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleusLateralDivisionCentralLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleusLateralDivisionDorsalLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleusLateralDivisionDorsalLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleusLateralDivisionExternalLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleusLateralDivisionExternalLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleusLateralDivisionSuperiorLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleusLateralDivisionSuperiorLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleusLateralDivisionVentralLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleusLateralDivisionVentralLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleusMedialDivision.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleusMedialDivision.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleusMedialDivisionExternalMedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleusMedialDivisionExternalMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleusMedialDivisionMedialMedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleusMedialDivisionMedialMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleusMedialDivisionVentralMedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parabrachialNucleusMedialDivisionVentralMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paracentralNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paracentralNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parafascicularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parafascicularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parafloccularSulcus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parafloccularSulcus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraflocculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraflocculus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraflocculusGranularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraflocculusGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraflocculusMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraflocculusMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraflocculusPurkinjeLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraflocculusPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paragigantocellularReticularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paragigantocellularReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paragigantocellularReticularNucleusDorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paragigantocellularReticularNucleusDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paragigantocellularReticularNucleusLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paragigantocellularReticularNucleusLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paramedianLobule.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paramedianLobule.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paramedianLobuleGranularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paramedianLobuleGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paramedianLobuleMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paramedianLobuleMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paramedianLobulePurkinjeLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paramedianLobulePurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paramedianReticularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paramedianReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paramedianSulcus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paramedianSulcus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paranigralNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paranigralNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parapyramidalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parapyramidalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parapyramidalNucleusDeepPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parapyramidalNucleusDeepPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parapyramidalNucleusSuperficialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parapyramidalNucleusSuperficialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parasolitaryNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parasolitaryNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parastrialNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parastrialNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parasubiculum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parasubiculum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parasubiculumLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parasubiculumLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parasubiculumLayer2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parasubiculumLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parasubiculumLayer3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parasubiculumLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parasubthalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parasubthalamicNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parataenialNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parataenialNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paratrigeminalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paratrigeminalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paratrochlearNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paratrochlearNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusDescendingDivision.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusDescendingDivision.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusDescendingDivisionDorsalParvicellularPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusDescendingDivisionDorsalParvicellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusDescendingDivisionFornicealPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusDescendingDivisionFornicealPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusDescendingDivisionLateralParvicellularPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusDescendingDivisionLateralParvicellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusDescendingDivisionMedialParvicellularPartVentralZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusDescendingDivisionMedialParvicellularPartVentralZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusMagnocellularDivision.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusMagnocellularDivision.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusMagnocellularDivisionAnteriorMagnocellularPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusMagnocellularDivisionAnteriorMagnocellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusMagnocellularDivisionMedialMagnocellularPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusMagnocellularDivisionMedialMagnocellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusMagnocellularDivisionPosteriorMagnocellularPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusMagnocellularDivisionPosteriorMagnocellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusMagnocellularDivisionPosteriorMagnocellularPartLateralZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusMagnocellularDivisionPosteriorMagnocellularPartLateralZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusMagnocellularDivisionPosteriorMagnocellularPartMedialZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusMagnocellularDivisionPosteriorMagnocellularPartMedialZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusParvicellularDivision.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusParvicellularDivision.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusParvicellularDivisionAnteriorParvicellularPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusParvicellularDivisionAnteriorParvicellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusParvicellularDivisionMedialParvicellularPartDorsalZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusParvicellularDivisionMedialParvicellularPartDorsalZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusParvicellularDivisionPeriventricularPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularHypothalamicNucleusParvicellularDivisionPeriventricularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularNucleusOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_paraventricularNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parvicellularMotor5Nucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parvicellularMotor5Nucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parvicellularReticularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_parvicellularReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pedunculopontineNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pedunculopontineNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_perforantPath.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_perforantPath.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_periaqueductalGray.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_periaqueductalGray.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_perifornicalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_perifornicalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_perihypoglossalNuclei.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_perihypoglossalNuclei.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_peripeduncularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_peripeduncularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_perireunensisNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_perireunensisNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_perirhinalArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_perirhinalArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_perirhinalAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_perirhinalAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_perirhinalAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_perirhinalAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_perirhinalAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_perirhinalAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_perirhinalAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_perirhinalAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_perirhinalAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_perirhinalAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_peritrigeminalZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_peritrigeminalZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_periventricularBundleOfTheHypothalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_periventricularBundleOfTheHypothalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_periventricularBundleOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_periventricularBundleOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_periventricularHypothalamicNucleusAnteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_periventricularHypothalamicNucleusAnteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_periventricularHypothalamicNucleusIntermediatePart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_periventricularHypothalamicNucleusIntermediatePart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_periventricularHypothalamicNucleusPosteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_periventricularHypothalamicNucleusPosteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_periventricularHypothalamicNucleusPreopticPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_periventricularHypothalamicNucleusPreopticPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_periventricularRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_periventricularRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_periventricularZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_periventricularZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pinealBody.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pinealBody.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pinealStalk.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pinealStalk.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_piriformArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_piriformArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_piriformAreaLayers13.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_piriformAreaLayers13.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_piriformAreaMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_piriformAreaMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_piriformAreaPolymorphLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_piriformAreaPolymorphLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_piriformAreaPyramidalLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_piriformAreaPyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_piriformamygdalarArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_piriformamygdalarArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_piriformamygdalarAreaLayers13.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_piriformamygdalarAreaLayers13.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_piriformamygdalarAreaMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_piriformamygdalarAreaMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_piriformamygdalarAreaPolymorphLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_piriformamygdalarAreaPolymorphLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_piriformamygdalarAreaPyramidalLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_piriformamygdalarAreaPyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pons.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pons.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ponsBehavioralStateRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ponsBehavioralStateRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ponsMotorRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ponsMotorRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ponsSensoryRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ponsSensoryRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pontineCentralGray.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pontineCentralGray.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pontineGray.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pontineGray.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pontineReticularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pontineReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pontineReticularNucleusCaudalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pontineReticularNucleusCaudalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pontineReticularNucleusVentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pontineReticularNucleusVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postcommissuralFornix.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postcommissuralFornix.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorAmygdalarNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorAmygdalarNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorAuditoryArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorAuditoryArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorAuditoryAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorAuditoryAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorAuditoryAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorAuditoryAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorAuditoryAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorAuditoryAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorAuditoryAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorAuditoryAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorAuditoryAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorAuditoryAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorAuditoryAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorAuditoryAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorComplexOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorComplexOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorHypothalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorHypothalamicNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorIntralaminarThalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorIntralaminarThalamicNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorLimitingNucleusOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorLimitingNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorParietalAssociationAreas.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorParietalAssociationAreas.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorParietalAssociationAreasLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorParietalAssociationAreasLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorParietalAssociationAreasLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorParietalAssociationAreasLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorParietalAssociationAreasLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorParietalAssociationAreasLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorParietalAssociationAreasLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorParietalAssociationAreasLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorParietalAssociationAreasLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorParietalAssociationAreasLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorParietalAssociationAreasLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorParietalAssociationAreasLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorPretectalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorPretectalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorSuperiorFissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorSuperiorFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorTriangularThalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteriorTriangularThalamicNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posterodorsalPreopticNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posterodorsalPreopticNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posterodorsalTegmentalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posterodorsalTegmentalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posterolateralFissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posterolateralFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posterolateralVisualArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posterolateralVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posterolateralVisualAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posterolateralVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posterolateralVisualAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posterolateralVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posterolateralVisualAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posterolateralVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posterolateralVisualAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posterolateralVisualAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posterolateralVisualAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posterolateralVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posterolateralVisualAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posterolateralVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteromedialVisualArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteromedialVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteromedialVisualAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteromedialVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteromedialVisualAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteromedialVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteromedialVisualAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteromedialVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteromedialVisualAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteromedialVisualAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteromedialVisualAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteromedialVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteromedialVisualAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_posteromedialVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postpiriformTransitionArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postpiriformTransitionArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postpiriformTransitionAreaLayers1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postpiriformTransitionAreaLayers1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postpiriformTransitionAreaLayers13.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postpiriformTransitionAreaLayers13.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postpiriformTransitionAreaLayers2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postpiriformTransitionAreaLayers2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postpiriformTransitionAreaLayers3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postpiriformTransitionAreaLayers3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postrhinalArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postrhinalArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postrhinalAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postrhinalAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postrhinalAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postrhinalAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postrhinalAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postrhinalAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postrhinalAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postrhinalAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postrhinalAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postrhinalAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postrhinalAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postrhinalAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postsubiculum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postsubiculum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postsubiculumLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postsubiculumLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postsubiculumLayer2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postsubiculumLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postsubiculumLayer3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_postsubiculumLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_precentralFissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_precentralFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_precommissuralFornixDiagonalBand.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_precommissuralFornixDiagonalBand.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_precommissuralFornixGeneral.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_precommissuralFornixGeneral.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_precommissuralNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_precommissuralNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_preculminateFissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_preculminateFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prelimbicArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prelimbicArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prelimbicAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prelimbicAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prelimbicAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prelimbicAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prelimbicAreaLayer2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prelimbicAreaLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prelimbicAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prelimbicAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prelimbicAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prelimbicAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prelimbicAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prelimbicAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_premammillaryCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_premammillaryCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_preopticCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_preopticCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_preparasubthalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_preparasubthalamicNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prepyramidalFissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prepyramidalFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_presubiculum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_presubiculum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_presubiculumLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_presubiculumLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_presubiculumLayer2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_presubiculumLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_presubiculumLayer3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_presubiculumLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pretectalRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pretectalRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryAuditoryArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryAuditoryArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryAuditoryAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryAuditoryAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryAuditoryAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryAuditoryAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryAuditoryAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryAuditoryAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryAuditoryAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryAuditoryAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryAuditoryAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryAuditoryAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryAuditoryAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryAuditoryAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryFissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryMotorArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryMotorArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryMotorAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryMotorAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryMotorAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryMotorAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryMotorAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryMotorAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryMotorAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryMotorAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryMotorAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryMotorAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaBarrelField.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaBarrelField.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaBarrelFieldLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaBarrelFieldLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaBarrelFieldLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaBarrelFieldLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaBarrelFieldLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaBarrelFieldLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaBarrelFieldLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaBarrelFieldLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaBarrelFieldLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaBarrelFieldLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaBarrelFieldLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaBarrelFieldLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLowerLimb.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLowerLimb.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLowerLimbLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLowerLimbLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLowerLimbLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLowerLimbLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLowerLimbLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLowerLimbLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLowerLimbLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLowerLimbLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLowerLimbLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLowerLimbLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLowerLimbLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaLowerLimbLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaMouth.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaMouth.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaMouthLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaMouthLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaMouthLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaMouthLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaMouthLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaMouthLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaMouthLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaMouthLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaMouthLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaMouthLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaMouthLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaMouthLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaNose.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaNose.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaNoseLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaNoseLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaNoseLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaNoseLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaNoseLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaNoseLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaNoseLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaNoseLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaNoseLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaNoseLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaNoseLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaNoseLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaTrunk.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaTrunk.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaTrunkLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaTrunkLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaTrunkLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaTrunkLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaTrunkLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaTrunkLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaTrunkLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaTrunkLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaTrunkLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaTrunkLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaTrunkLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaTrunkLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUnassigned.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUnassigned.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUnassignedLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUnassignedLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUnassignedLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUnassignedLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUnassignedLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUnassignedLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUnassignedLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUnassignedLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUnassignedLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUnassignedLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUnassignedLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUnassignedLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUpperLimb.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUpperLimb.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUpperLimbLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUpperLimbLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUpperLimbLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUpperLimbLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUpperLimbLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUpperLimbLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUpperLimbLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUpperLimbLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUpperLimbLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUpperLimbLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUpperLimbLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primarySomatosensoryAreaUpperLimbLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryVisualArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryVisualAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryVisualAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryVisualAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryVisualAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryVisualAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryVisualAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryVisualAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_primaryVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_principalMammillaryTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_principalMammillaryTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_principalSensoryNucleusOfTheTrigeminal.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_principalSensoryNucleusOfTheTrigeminal.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_propriohypothalamicPathways.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_propriohypothalamicPathways.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_propriohypothalamicPathwaysDorsal.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_propriohypothalamicPathwaysDorsal.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_propriohypothalamicPathwaysLateral.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_propriohypothalamicPathwaysLateral.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_propriohypothalamicPathwaysMedial.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_propriohypothalamicPathwaysMedial.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_propriohypothalamicPathwaysVentral.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_propriohypothalamicPathwaysVentral.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prosubiculum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prosubiculum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prosubiculumDorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prosubiculumDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prosubiculumDorsalPartMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prosubiculumDorsalPartMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prosubiculumDorsalPartPyramidalLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prosubiculumDorsalPartPyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prosubiculumDorsalPartStratumRadiatum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prosubiculumDorsalPartStratumRadiatum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prosubiculumVentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prosubiculumVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prosubiculumVentralPartMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prosubiculumVentralPartMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prosubiculumVentralPartPyramidalLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prosubiculumVentralPartPyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prosubiculumVentralPartStratumRadiatum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_prosubiculumVentralPartStratumRadiatum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pyramid.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pyramid.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pyramidalDecussation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pyramidalDecussation.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pyramusVIII.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pyramusVIII.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pyramusVIIIGranularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pyramusVIIIGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pyramusVIIIMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pyramusVIIIMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pyramusVIIIPurkinjeLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_pyramusVIIIPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_redNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_redNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_reticularNucleusOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_reticularNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_reticulocerebellarTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_reticulocerebellarTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retina.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retina.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retriculospinalTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retriculospinalTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retriculospinalTractLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retriculospinalTractLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retriculospinalTractMedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retriculospinalTractMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrochiasmaticArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrochiasmaticArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retroethmoidNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retroethmoidNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrohippocampalRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrohippocampalRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retroparafascicularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retroparafascicularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaDorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaDorsalPartLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaDorsalPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaDorsalPartLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaDorsalPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaDorsalPartLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaDorsalPartLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaDorsalPartLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaDorsalPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaDorsalPartLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaDorsalPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaDorsalPartLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaDorsalPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaLateralAgranularPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaLateralAgranularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaLateralAgranularPartLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaLateralAgranularPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaLateralAgranularPartLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaLateralAgranularPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaLateralAgranularPartLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaLateralAgranularPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaLateralAgranularPartLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaLateralAgranularPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaLateralAgranularPartLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaLateralAgranularPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaVentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaVentralPartLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaVentralPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaVentralPartLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaVentralPartLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaVentralPartLayer2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaVentralPartLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaVentralPartLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaVentralPartLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaVentralPartLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaVentralPartLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaVentralPartLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_retrosplenialAreaVentralPartLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rhinalFissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rhinalFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rhinalIncisure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rhinalIncisure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rhinocele.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rhinocele.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rhomboidNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rhomboidNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_root.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_root.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostralLinearNucleusRaphe.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostralLinearNucleusRaphe.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralLateralVisualArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralLateralVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralLateralVisualAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralLateralVisualAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralLateralVisualAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralLateralVisualAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralLateralVisualAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralLateralVisualAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralLateralVisualAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralLateralVisualAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralLateralVisualAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralLateralVisualAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralLateralVisualArealayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralLateralVisualArealayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralVisualArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rostrolateralVisualArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rubroreticularTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rubroreticularTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rubrospinalTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_rubrospinalTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_secondaryFissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_secondaryFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_secondaryMotorArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_secondaryMotorArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_secondaryMotorAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_secondaryMotorAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_secondaryMotorAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_secondaryMotorAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_secondaryMotorAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_secondaryMotorAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_secondaryMotorAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_secondaryMotorAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_secondaryMotorAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_secondaryMotorAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_sensoryRootOfTheTrigeminalNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_sensoryRootOfTheTrigeminalNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_septofimbrialNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_septofimbrialNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_septohippocampalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_septohippocampalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_simpleFissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_simpleFissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_simpleLobule.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_simpleLobule.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_simpleLobuleGranularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_simpleLobuleGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_simpleLobuleMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_simpleLobuleMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_simpleLobulePurkinjeLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_simpleLobulePurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_solitaryTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_solitaryTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatomotorAreas.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatomotorAreas.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatomotorAreasLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatomotorAreasLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatomotorAreasLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatomotorAreasLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatomotorAreasLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatomotorAreasLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatomotorAreasLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatomotorAreasLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatomotorAreasLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatomotorAreasLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatosensoryAreas.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatosensoryAreas.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatosensoryAreasLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatosensoryAreasLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatosensoryAreasLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatosensoryAreasLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatosensoryAreasLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatosensoryAreasLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatosensoryAreasLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatosensoryAreasLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatosensoryAreasLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatosensoryAreasLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatosensoryAreasLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_somatosensoryAreasLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinalNucleusOfTheTrigeminalCaudalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinalNucleusOfTheTrigeminalCaudalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinalNucleusOfTheTrigeminalInterpolarPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinalNucleusOfTheTrigeminalInterpolarPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinalNucleusOfTheTrigeminalOralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinalNucleusOfTheTrigeminalOralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinalNucleusOfTheTrigeminalOralPartCaudalDorsomedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinalNucleusOfTheTrigeminalOralPartCaudalDorsomedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinalNucleusOfTheTrigeminalOralPartMiddleDorsomedialPartDorsalZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinalNucleusOfTheTrigeminalOralPartMiddleDorsomedialPartDorsalZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinalNucleusOfTheTrigeminalOralPartMiddleDorsomedialPartVentralZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinalNucleusOfTheTrigeminalOralPartMiddleDorsomedialPartVentralZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinalNucleusOfTheTrigeminalOralPartRostralDorsomedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinalNucleusOfTheTrigeminalOralPartRostralDorsomedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinalNucleusOfTheTrigeminalOralPartVentrolateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinalNucleusOfTheTrigeminalOralPartVentrolateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinalTractOfTheTrigeminalNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinalTractOfTheTrigeminalNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinalVestibularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinalVestibularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinocerebellarTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinocerebellarTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinocervicalTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinocervicalTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinohypothalamicPathway.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinohypothalamicPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinoolivaryPathway.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinoolivaryPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinoreticularPathway.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinoreticularPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinotectalPathway.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinotectalPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinotelenchephalicPathway.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinotelenchephalicPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinothalamicTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinothalamicTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinovestibularPathway.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_spinovestibularPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_striaMedullaris.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_striaMedullaris.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_striaTerminalis.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_striaTerminalis.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_striatonigralPathway.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_striatonigralPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_striatum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_striatum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_striatumDorsalRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_striatumDorsalRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_striatumVentralRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_striatumVentralRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_striatumlikeAmygdalarNuclei.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_striatumlikeAmygdalarNuclei.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subceruleusNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subceruleusNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subcommissuralOrgan.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subcommissuralOrgan.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subependymalZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subependymalZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subfornicalOrgan.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subfornicalOrgan.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subgeniculateNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subgeniculateNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subiculum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subiculum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subiculumDorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subiculumDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subiculumDorsalPartMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subiculumDorsalPartMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subiculumDorsalPartPyramidalLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subiculumDorsalPartPyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subiculumDorsalPartStratumRadiatum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subiculumDorsalPartStratumRadiatum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subiculumVentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subiculumVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subiculumVentralPartMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subiculumVentralPartMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subiculumVentralPartPyramidalLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subiculumVentralPartPyramidalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subiculumVentralPartStratumRadiatum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subiculumVentralPartStratumRadiatum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_sublaterodorsalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_sublaterodorsalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_submedialNucleusOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_submedialNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subparafascicularArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subparafascicularArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subparafascicularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subparafascicularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subparafascicularNucleusMagnocellularPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subparafascicularNucleusMagnocellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subparafascicularNucleusParvicellularPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subparafascicularNucleusParvicellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subparaventricularZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subparaventricularZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_substantiaInnominata.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_substantiaInnominata.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_substantiaNigraCompactPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_substantiaNigraCompactPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_substantiaNigraLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_substantiaNigraLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_substantiaNigraReticularPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_substantiaNigraReticularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subthalamicFascicle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subthalamicFascicle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subthalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_subthalamicNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorCentralNucleusRaphe.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorCentralNucleusRaphe.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorCentralNucleusRapheLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorCentralNucleusRapheLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorCentralNucleusRapheMedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorCentralNucleusRapheMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorCerebelarPeduncles.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorCerebelarPeduncles.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorCerebellarPeduncleDecussation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorCerebellarPeduncleDecussation.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusMotorRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusMotorRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusMotorRelatedDeepGrayLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusMotorRelatedDeepGrayLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusMotorRelatedDeepWhiteLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusMotorRelatedDeepWhiteLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusMotorRelatedIntermediateGrayLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusMotorRelatedIntermediateGrayLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusMotorRelatedIntermediateGrayLayerSublayerA.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusMotorRelatedIntermediateGrayLayerSublayerA.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusMotorRelatedIntermediateGrayLayerSublayerB.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusMotorRelatedIntermediateGrayLayerSublayerB.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusMotorRelatedIntermediateGrayLayerSublayerC.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusMotorRelatedIntermediateGrayLayerSublayerC.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusMotorRelatedIntermediateWhiteLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusMotorRelatedIntermediateWhiteLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusOpticLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusOpticLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusSensoryRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusSensoryRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusSuperficialGrayLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusSuperficialGrayLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusZonalLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorColliculusZonalLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorOlivaryComplex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorOlivaryComplex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorOlivaryComplexLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorOlivaryComplexLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorOlivaryComplexMedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorOlivaryComplexMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorOlivaryComplexPeriolivaryRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorOlivaryComplexPeriolivaryRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorSalivatoryNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorSalivatoryNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorVestibularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_superiorVestibularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supplementalSomatosensoryArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supplementalSomatosensoryArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supplementalSomatosensoryAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supplementalSomatosensoryAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supplementalSomatosensoryAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supplementalSomatosensoryAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supplementalSomatosensoryAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supplementalSomatosensoryAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supplementalSomatosensoryAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supplementalSomatosensoryAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supplementalSomatosensoryAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supplementalSomatosensoryAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supplementalSomatosensoryAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supplementalSomatosensoryAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supracallosalCerebralWhiteMatter.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supracallosalCerebralWhiteMatter.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_suprachiasmaticNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_suprachiasmaticNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_suprachiasmaticPreopticNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_suprachiasmaticPreopticNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_suprageniculateNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_suprageniculateNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supragenualNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supragenualNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supramammillaryDecussation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supramammillaryDecussation.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supramammillaryNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supramammillaryNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supramammillaryNucleusLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supramammillaryNucleusLateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supramammillaryNucleusMedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supramammillaryNucleusMedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supraoculomotorPeriaqueductalGray.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supraoculomotorPeriaqueductalGray.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supraopticCommissures.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supraopticCommissures.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supraopticCommissuresAnterior.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supraopticCommissuresAnterior.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supraopticCommissuresDorsal.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supraopticCommissuresDorsal.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supraopticCommissuresVentral.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supraopticCommissuresVentral.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supraopticNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supraopticNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supratrigeminalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_supratrigeminalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTecta.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTecta.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaDorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaDorsalPartLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaDorsalPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaDorsalPartLayer2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaDorsalPartLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaDorsalPartLayer3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaDorsalPartLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaDorsalPartLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaDorsalPartLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaDorsalPartLayers14.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaDorsalPartLayers14.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaVentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaVentralPartLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaVentralPartLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaVentralPartLayer2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaVentralPartLayer2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaVentralPartLayer3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaVentralPartLayer3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaVentralPartLayers13.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_taeniaTectaVentralPartLayers13.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_tectospinalPathway.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_tectospinalPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_tectothalamicPathway.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_tectothalamicPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_tegmentalReticularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_tegmentalReticularNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_temporalAssociationAreas.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_temporalAssociationAreas.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_temporalAssociationAreasLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_temporalAssociationAreasLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_temporalAssociationAreasLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_temporalAssociationAreasLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_temporalAssociationAreasLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_temporalAssociationAreasLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_temporalAssociationAreasLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_temporalAssociationAreasLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_temporalAssociationAreasLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_temporalAssociationAreasLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_temporalAssociationAreasLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_temporalAssociationAreasLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_terminalNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_terminalNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_thalamicPeduncles.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_thalamicPeduncles.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_thalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_thalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_thalamusPolymodalAssociationCortexRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_thalamusPolymodalAssociationCortexRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_thalamusRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_thalamusRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_thalamusSensorymotorCortexRelated.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_thalamusSensorymotorCortexRelated.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_thirdVentricle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_thirdVentricle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_trapezoidBody.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_trapezoidBody.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_triangularNucleusOfSeptum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_triangularNucleusOfSeptum.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_trigeminalNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_trigeminalNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_trigeminocerebellarTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_trigeminocerebellarTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_trochlearNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_trochlearNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_trochlearNerveDecussation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_trochlearNerveDecussation.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_trochlearNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_trochlearNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_tuberalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_tuberalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_tuberomammillaryNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_tuberomammillaryNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_tuberomammillaryNucleusDorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_tuberomammillaryNucleusDorsalPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_tuberomammillaryNucleusVentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_tuberomammillaryNucleusVentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_uncinateFascicle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_uncinateFascicle.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_uvulaIX.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_uvulaIX.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_uvulaIXGranularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_uvulaIXGranularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_uvulaIXMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_uvulaIXMolecularLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_uvulaIXPurkinjeLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_uvulaIXPurkinjeLayer.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_vagusNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_vagusNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_vascularOrganOfTheLaminaTerminalis.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_vascularOrganOfTheLaminaTerminalis.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralAnteriorlateralComplexOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralAnteriorlateralComplexOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralAuditoryArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralAuditoryArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralAuditoryAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralAuditoryAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralAuditoryAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralAuditoryAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralAuditoryAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralAuditoryAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralAuditoryAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralAuditoryAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralAuditoryAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralAuditoryAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralAuditoryAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralAuditoryAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralCochlearNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralCochlearNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralCommissureOfTheSpinalCord.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralCommissureOfTheSpinalCord.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralGroupOfTheDorsalThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralGroupOfTheDorsalThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralHippocampalCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralHippocampalCommissure.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralMedialNucleusOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralMedialNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralPartOfTheLateralGeniculateComplex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralPartOfTheLateralGeniculateComplex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralPartOfTheLateralGeniculateComplexLateralZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralPartOfTheLateralGeniculateComplexLateralZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralPartOfTheLateralGeniculateComplexMedialZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralPartOfTheLateralGeniculateComplexMedialZone.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralPosteriorComplexOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralPosteriorComplexOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralPosterolateralNucleusOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralPosterolateralNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralPosterolateralNucleusOfTheThalamusParvicellularPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralPosterolateralNucleusOfTheThalamusParvicellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralPosteromedialNucleusOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralPosteromedialNucleusOfTheThalamus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralPosteromedialNucleusOfTheThalamusParvicellularPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralPosteromedialNucleusOfTheThalamusParvicellularPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralPremammillaryNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralPremammillaryNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralRoots.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralRoots.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralSpinocerebellarTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralSpinocerebellarTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralSpinothalamicTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralSpinothalamicTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralTegmentalArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralTegmentalArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralTegmentalDecussation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralTegmentalDecussation.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralTegmentalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventralTegmentalNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventricularSystems.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventricularSystems.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventrolateralHypothalamicTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventrolateralHypothalamicTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventrolateralPreopticNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventrolateralPreopticNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventromedialHypothalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventromedialHypothalamicNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventromedialHypothalamicNucleusAnteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventromedialHypothalamicNucleusAnteriorPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventromedialHypothalamicNucleusCentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventromedialHypothalamicNucleusCentralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventromedialHypothalamicNucleusDorsomedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventromedialHypothalamicNucleusDorsomedialPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventromedialHypothalamicNucleusVentrolateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventromedialHypothalamicNucleusVentrolateralPart.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventromedialPreopticNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_ventromedialPreopticNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_vermalRegions.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_vermalRegions.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_vestibularNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_vestibularNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_vestibularNuclei.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_vestibularNuclei.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_vestibulocerebellarNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_vestibulocerebellarNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_vestibulocochlearNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_vestibulocochlearNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_vestibulospinalPathway.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_vestibulospinalPathway.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visceralArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visceralArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visceralAreaLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visceralAreaLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visceralAreaLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visceralAreaLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visceralAreaLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visceralAreaLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visceralAreaLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visceralAreaLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visceralAreaLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visceralAreaLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visceralAreaLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visceralAreaLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visualAreas.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visualAreas.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visualAreasLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visualAreasLayer1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visualAreasLayer2-3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visualAreasLayer2-3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visualAreasLayer4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visualAreasLayer4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visualAreasLayer5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visualAreasLayer5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visualAreasLayer6a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visualAreasLayer6a.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visualAreasLayer6b.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_visualAreasLayer6b.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_vomeronasalNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_vomeronasalNerve.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_xiphoidThalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_xiphoidThalamicNucleus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_zonaIncerta.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/AMBA_CCFv3-2017/AMBA_CCFv3-2017_zonaIncerta.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA1.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA10.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA10.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA11.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA11.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA12.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA12.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA13.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA13.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA14.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA14.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA15.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA15.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA16.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA16.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA17.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA17.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA18.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA18.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA19.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA19.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA2.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA20.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA20.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA21.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA21.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA22.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA22.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA23.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA23.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA24.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA24.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA25.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA25.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA26.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA26.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA27.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA27.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA28.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA28.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA29.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA29.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA3.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA30.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA30.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA31.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA31.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA32.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA32.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA33.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA33.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA34.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA34.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA35.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA35.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA36.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA36.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA37.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA37.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA38.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA38.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA39.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA39.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA4.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA40.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA40.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA41.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA41.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA42.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA42.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA43.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA43.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA44.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA44.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA45.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA45.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA46.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA46.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA47.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA47.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA48.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA48.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA5.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA52.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA52.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA6.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA6.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA7.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA7.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA8.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA8.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA8a.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA8a.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA9.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/BA-human_1909/BA-human_1909_BA9.jsonld
@@ -16,7 +16,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/asserted"

--- a/instances/v5.0/parcellationEntityVersions/DWMA_2018/DWMA_2018_anteriorSegementOfArcuateFasciculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/DWMA_2018/DWMA_2018_anteriorSegementOfArcuateFasciculus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -34,7 +33,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/DWMA_2018/DWMA_2018_corticospinalTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/DWMA_2018/DWMA_2018_corticospinalTract.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -34,7 +33,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/DWMA_2018/DWMA_2018_directSegementOfArcuateFasciculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/DWMA_2018/DWMA_2018_directSegementOfArcuateFasciculus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -34,7 +33,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/DWMA_2018/DWMA_2018_fornix.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/DWMA_2018/DWMA_2018_fornix.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -34,7 +33,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/DWMA_2018/DWMA_2018_inferiorFronto-occipitalFasciculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/DWMA_2018/DWMA_2018_inferiorFronto-occipitalFasciculus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -34,7 +33,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/DWMA_2018/DWMA_2018_inferiorLongitudinalFasciculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/DWMA_2018/DWMA_2018_inferiorLongitudinalFasciculus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -34,7 +33,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/DWMA_2018/DWMA_2018_longCingulateFibres.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/DWMA_2018/DWMA_2018_longCingulateFibres.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -34,7 +33,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/DWMA_2018/DWMA_2018_posteriorSegementOfArcuateFasciculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/DWMA_2018/DWMA_2018_posteriorSegementOfArcuateFasciculus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -34,7 +33,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/DWMA_2018/DWMA_2018_shortCingulateFibres.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/DWMA_2018/DWMA_2018_shortCingulateFibres.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -34,7 +33,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/DWMA_2018/DWMA_2018_temporalCingulateFibres.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/DWMA_2018/DWMA_2018_temporalCingulateFibres.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -34,7 +33,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/DWMA_2018/DWMA_2018_uncinateFasciculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/DWMA_2018/DWMA_2018_uncinateFasciculus.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -34,7 +33,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-1_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-1_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-25_PM-v16.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-25_PM-v16.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-33_PM-v16.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-33_PM-v16.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-3a_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-3a_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-3b_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-3b_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-44_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-44_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-45_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-45_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-4a_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-4a_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-4p_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-4p_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-5Ci_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-5Ci_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-5L_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-5L_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-5M_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-5M_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-7A_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-7A_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-7M_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-7M_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-7PC_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-7PC_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-7P_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-7P_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-FG1_PM-v1.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-FG1_PM-v1.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-FG2_PM-v1.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-FG2_PM-v1.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-FG3_PM-v6.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-FG3_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-FG4_PM-v6.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-FG4_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-Fo1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-Fo1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-Fo2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-Fo2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-Fo3_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-Fo3_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-Fp1_PM-v2.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-Fp1_PM-v2.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-Fp2_PM-v2.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-Fp2_PM-v2.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-Id1_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-Id1_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-Ig1_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-Ig1_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-Ig2_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-Ig2_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-OP1_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-OP1_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-OP2_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-OP2_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-OP3_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-OP3_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-OP4_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-OP4_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-PF_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-PF_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-PFcm_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-PFcm_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-PFm_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-PFm_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-PFop_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-PFop_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-PFt_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-PFt_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-PGa_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-PGa_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-PGp_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-PGp_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-TE-1.0_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-TE-1.0_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-TE-1.1_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-TE-1.1_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-TE-1.2_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-TE-1.2_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-TE-3_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-TE-3_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hIP1_PM-v6.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hIP1_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hIP2_PM-v6.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hIP2_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hIP3_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hIP3_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hOc1_PM-v2.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hOc1_PM-v2.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hOc2_PM-v2.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hOc2_PM-v2.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hOc3d_PM-v2.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hOc3d_PM-v2.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hOc3v_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hOc3v_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hOc4d_PM-v2.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hOc4d_PM-v2.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hOc4la_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hOc4la_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hOc4lp_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hOc4lp_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hOc4v_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hOc4v_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hOc5_PM-v2.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-hOc5_PM-v2.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-s24_PM-v16.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-s24_PM-v16.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-s32_PM-v16.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Area-s32_PM-v16.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_CA1_PM-v11b.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_CA1_PM-v11b.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_CA2_PM-v11b.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_CA2_PM-v11b.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_CA3_PM-v11b.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_CA3_PM-v11b.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_CM_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_CM_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Ch-123_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Ch-123_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Ch-4_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Ch-4_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_DG_PM-v11b.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_DG_PM-v11b.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Dorsal-Dentate-Nucleus_PM-v6.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Dorsal-Dentate-Nucleus_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Entorhinal-Cortex_PM-v11b.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Entorhinal-Cortex_PM-v11b.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Fastigial-Nucleus_PM-v6.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Fastigial-Nucleus_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_HATA_PM-v11b.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_HATA_PM-v11b.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_IF_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_IF_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Interposed-Nucleus_PM-v6.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Interposed-Nucleus_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_LB_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_LB_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_MF_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_MF_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_SF_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_SF_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Subiculum_PM-v11b.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Subiculum_PM-v11b.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_VTM_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_VTM_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Ventral-Dentate-Nucleus_PM-v6.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.13-Colin27/JBA_v1.13-Colin27_Ventral-Dentate-Nucleus_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-1_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-1_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-25_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-25_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-2_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-2_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-33_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-33_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-3a_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-3a_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-3b_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-3b_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-44_PM-v7.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-44_PM-v7.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-45_PM-v7.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-45_PM-v7.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-4a_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-4a_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-4p_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-4p_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-5Ci_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-5Ci_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-5L_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-5L_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-5M_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-5M_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-6d1_PM-v4.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-6d1_PM-v4.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-6d2_PM-v4.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-6d2_PM-v4.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-6d3_PM-v4.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-6d3_PM-v4.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-6ma_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-6ma_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-6mp_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-6mp_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-7A_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-7A_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-7M_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-7M_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-7PC_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-7PC_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-7P_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-7P_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-FG1_PM-v1.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-FG1_PM-v1.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-FG2_PM-v1.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-FG2_PM-v1.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-FG3_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-FG3_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-FG4_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-FG4_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Fo1_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Fo1_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Fo2_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Fo2_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Fo3_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Fo3_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Fo4_PM-v2.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Fo4_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Fo5_PM-v2.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Fo5_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Fo6_PM-v2.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Fo6_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Fo7_PM-v2.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Fo7_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Fp1_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Fp1_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Fp2_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Fp2_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Ia_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Ia_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Id1_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Id1_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Id2_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Id2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Id3_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Id3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Id4_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Id4_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Id5_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Id5_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Id6_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Id6_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Id7_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Id7_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Ig1_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Ig1_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Ig2_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Ig2_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Ig3_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-Ig3_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-OP1_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-OP1_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-OP2_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-OP2_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-OP3_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-OP3_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-OP4_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-OP4_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-OP8_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-OP8_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-OP9_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-OP9_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-PF_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-PF_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-PFcm_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-PFcm_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-PFm_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-PFm_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-PFop_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-PFop_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-PFt_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-PFt_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-PGa_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-PGa_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-PGp_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-PGp_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-STS1_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-STS1_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-STS2_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-STS2_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-TE-1.0_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-TE-1.0_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-TE-1.1_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-TE-1.1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-TE-1.2_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-TE-1.2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-TE-3_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-TE-3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hIP1_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hIP1_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hIP2_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hIP2_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hIP3_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hIP3_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hIP4_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hIP4_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hIP5_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hIP5_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hIP6_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hIP6_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hIP7_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hIP7_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hIP8_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hIP8_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hOc1_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hOc1_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hOc2_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hOc2_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hOc3d_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hOc3d_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hOc3v_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hOc3v_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hOc4d_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hOc4d_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hOc4la_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hOc4la_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hOc4lp_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hOc4lp_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hOc4v_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hOc4v_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hOc5_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hOc5_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hOc6_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hOc6_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hPO1_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-hPO1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-p24ab_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-p24ab_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-p24c_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-p24c_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-p32_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-p32_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-s24_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-s24_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-s32_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Area-s32_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_CA_PM-v11.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_CA_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_CM_PM-v6.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_CM_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Ch-123_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Ch-123_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Ch-4_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Ch-4_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_DG_PM-v11.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_DG_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Dorsal-Dentate-Nucleus_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Dorsal-Dentate-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Entorhinal-Cortex_PM-v11.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Entorhinal-Cortex_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Fastigial-Nucleus_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Fastigial-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_HATA_PM-v11.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_HATA_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_IF_PM-v6.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_IF_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Interposed-Nucleus_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Interposed-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_LB_PM-v6.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_LB_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_MF_PM-v6.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_MF_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_SF_PM-v6.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_SF_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Subiculum_PM-v11.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Subiculum_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_VTM_PM-v6.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_VTM_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Ventral-Dentate-Nucleus_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-Colin27/JBA_v1.18-Colin27_Ventral-Dentate-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-1_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-1_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-25_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-25_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-2_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-2_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-33_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-33_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-3a_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-3a_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-3b_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-3b_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-44_PM-v7.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-44_PM-v7.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-45_PM-v7.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-45_PM-v7.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-4a_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-4a_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-4p_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-4p_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-5Ci_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-5Ci_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-5L_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-5L_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-5M_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-5M_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-6d1_PM-v4.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-6d1_PM-v4.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-6d2_PM-v4.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-6d2_PM-v4.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-6d3_PM-v4.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-6d3_PM-v4.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-6ma_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-6ma_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-6mp_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-6mp_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-7A_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-7A_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-7M_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-7M_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-7PC_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-7PC_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-7P_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-7P_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-FG1_PM-v1.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-FG1_PM-v1.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-FG2_PM-v1.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-FG2_PM-v1.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-FG3_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-FG3_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-FG4_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-FG4_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Fo1_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Fo1_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Fo2_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Fo2_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Fo3_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Fo3_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Fo4_PM-v2.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Fo4_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Fo5_PM-v2.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Fo5_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Fo6_PM-v2.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Fo6_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Fo7_PM-v2.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Fo7_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Fp1_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Fp1_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Fp2_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Fp2_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Ia_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Ia_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Id1_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Id1_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Id2_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Id2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Id3_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Id3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Id4_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Id4_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Id5_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Id5_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Id6_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Id6_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Id7_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Id7_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Ig1_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Ig1_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Ig2_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Ig2_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Ig3_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-Ig3_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-OP1_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-OP1_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-OP2_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-OP2_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-OP3_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-OP3_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-OP4_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-OP4_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-OP8_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-OP8_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-OP9_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-OP9_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-PF_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-PF_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-PFcm_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-PFcm_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-PFm_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-PFm_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-PFop_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-PFop_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-PFt_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-PFt_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-PGa_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-PGa_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-PGp_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-PGp_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-STS1_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-STS1_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-STS2_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-STS2_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-TE-1.0_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-TE-1.0_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-TE-1.1_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-TE-1.1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-TE-1.2_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-TE-1.2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-TE-3_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-TE-3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hIP1_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hIP1_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hIP2_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hIP2_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hIP3_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hIP3_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hIP4_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hIP4_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hIP5_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hIP5_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hIP6_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hIP6_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hIP7_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hIP7_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hIP8_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hIP8_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hOc1_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hOc1_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hOc2_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hOc2_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hOc3d_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hOc3d_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hOc3v_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hOc3v_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hOc4d_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hOc4d_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hOc4la_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hOc4la_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hOc4lp_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hOc4lp_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hOc4v_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hOc4v_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hOc5_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hOc5_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hOc6_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hOc6_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hPO1_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-hPO1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-p24ab_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-p24ab_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-p24c_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-p24c_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-p32_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-p32_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-s24_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-s24_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-s32_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Area-s32_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_CA_PM-v11.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_CA_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_CM_PM-v6.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_CM_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Ch-123_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Ch-123_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Ch-4_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Ch-4_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_DG_PM-v11.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_DG_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Dorsal-Dentate-Nucleus_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Dorsal-Dentate-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Entorhinal-Cortex_PM-v11.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Entorhinal-Cortex_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Fastigial-Nucleus_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Fastigial-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_HATA_PM-v11.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_HATA_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_IF_PM-v6.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_IF_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Interposed-Nucleus_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Interposed-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_LB_PM-v6.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_LB_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_MF_PM-v6.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_MF_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_SF_PM-v6.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_SF_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Subiculum_PM-v11.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Subiculum_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_VTM_PM-v6.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_VTM_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Ventral-Dentate-Nucleus_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v1.18-MNI152/JBA_v1.18-MNI152_Ventral-Dentate-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-1_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-1_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-25_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-25_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-2_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-2_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-33_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-33_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-3a_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-3a_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-3b_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-3b_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-44_PM-v7.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-44_PM-v7.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-45_PM-v7.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-45_PM-v7.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-4a_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-4a_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-4p_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-4p_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-5Ci_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-5Ci_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-5L_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-5L_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-5M_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-5M_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-6d1_PM-v4.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-6d1_PM-v4.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-6d2_PM-v4.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-6d2_PM-v4.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-6d3_PM-v4.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-6d3_PM-v4.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-6ma_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-6ma_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-6mp_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-6mp_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-7A_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-7A_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-7PC_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-7PC_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-7P_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-7P_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-FG1_PM-v1.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-FG1_PM-v1.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-FG2_PM-v1.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-FG2_PM-v1.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-FG3_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-FG3_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-FG4_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-FG4_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Fo1_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Fo1_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Fo2_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Fo2_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Fo3_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Fo3_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Fo4_PM-v2.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Fo4_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Fo5_PM-v2.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Fo5_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Fo6_PM-v2.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Fo6_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Fo7_PM-v2.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Fo7_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Fp1_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Fp1_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Fp2_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Fp2_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Ia_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Ia_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Id1_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Id1_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Id2_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Id2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Id3_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Id3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Id4_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Id4_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Id5_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Id5_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Id6_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Id6_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Id7_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Id7_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Ig1_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Ig1_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Ig2_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Ig2_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Ig3_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-Ig3_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-OP1_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-OP1_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-OP2_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-OP2_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-OP3_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-OP3_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-OP4_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-OP4_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-OP5_PM-v2.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-OP5_PM-v2.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-OP6_PM-v2.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-OP6_PM-v2.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-OP7_PM-v2.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-OP7_PM-v2.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-OP8_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-OP8_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-OP9_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-OP9_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-PF_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-PF_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-PFcm_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-PFcm_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-PFm_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-PFm_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-PFop_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-PFop_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-PFt_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-PFt_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-PGa_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-PGa_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-PGp_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-PGp_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-STS1_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-STS1_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-STS2_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-STS2_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-TE-1.0_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-TE-1.0_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-TE-1.1_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-TE-1.1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-TE-1.2_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-TE-1.2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-TE-2.1_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-TE-2.1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-TE-2.2_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-TE-2.2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-TE-3_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-TE-3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-TI_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-TI_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-TeI_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-TeI_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-a29_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-a29_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-a30_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-a30_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hIP1_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hIP1_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hIP2_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hIP2_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hIP3_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hIP3_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hIP4_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hIP4_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hIP5_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hIP5_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hIP6_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hIP6_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hIP7_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hIP7_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hIP8_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hIP8_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hOc1_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hOc1_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hOc2_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hOc2_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hOc3d_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hOc3d_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hOc3v_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hOc3v_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hOc4d_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hOc4d_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hOc4la_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hOc4la_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hOc4lp_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hOc4lp_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hOc4v_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hOc4v_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hOc5_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hOc5_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hOc6_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hOc6_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hPO1_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-hPO1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-i29_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-i29_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-i30_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-i30_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-p24ab_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-p24ab_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-p24c_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-p24c_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-p29_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-p29_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-p30_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-p30_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-p32_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-p32_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-s24_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-s24_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-s32_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Area-s32_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_CA1_PM-v11.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_CA1_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_CA2_PM-v11.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_CA2_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_CA3_PM-v11.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_CA3_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_CM_PM-v6.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_CM_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Ch-123_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Ch-123_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Ch-4_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Ch-4_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_DG_PM-v11.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_DG_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Dorsal-Dentate-Nucleus_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Dorsal-Dentate-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Entorhinal-Cortex_PM-v11.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Entorhinal-Cortex_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Fastigial-Nucleus_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Fastigial-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Frontal-II_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Frontal-II_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Frontal-I_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Frontal-I_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Frontal-to-Occipital_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Frontal-to-Occipital_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Frontal-to-Temporal_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Frontal-to-Temporal_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_HATA_PM-v11.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_HATA_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_IF_PM-v6.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_IF_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Interposed-Nucleus_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Interposed-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_LB_PM-v6.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_LB_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_MF_PM-v6.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_MF_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_SF_PM-v6.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_SF_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Subiculum_PM-v11.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Subiculum_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Temporal-to-Parietal_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Temporal-to-Parietal_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_VTM_PM-v6.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_VTM_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Ventral-Dentate-Nucleus_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-Colin27/JBA_v2.2-Colin27_Ventral-Dentate-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-1_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-1_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-25_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-25_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-2_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-2_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-33_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-33_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-3a_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-3a_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-3b_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-3b_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-44_PM-v7.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-44_PM-v7.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-45_PM-v7.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-45_PM-v7.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-4a_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-4a_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-4p_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-4p_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-5Ci_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-5Ci_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-5L_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-5L_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-5M_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-5M_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-6d1_PM-v4.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-6d1_PM-v4.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-6d2_PM-v4.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-6d2_PM-v4.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-6d3_PM-v4.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-6d3_PM-v4.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-6ma_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-6ma_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-6mp_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-6mp_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-7A_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-7A_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-7PC_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-7PC_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-7P_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-7P_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-FG1_PM-v1.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-FG1_PM-v1.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-FG2_PM-v1.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-FG2_PM-v1.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-FG3_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-FG3_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-FG4_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-FG4_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Fo1_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Fo1_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Fo2_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Fo2_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Fo3_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Fo3_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Fo4_PM-v2.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Fo4_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Fo5_PM-v2.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Fo5_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Fo6_PM-v2.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Fo6_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Fo7_PM-v2.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Fo7_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Fp1_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Fp1_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Fp2_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Fp2_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Ia_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Ia_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Id1_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Id1_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Id2_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Id2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Id3_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Id3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Id4_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Id4_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Id5_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Id5_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Id6_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Id6_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Id7_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Id7_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Ig1_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Ig1_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Ig2_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Ig2_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Ig3_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-Ig3_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-OP1_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-OP1_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-OP2_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-OP2_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-OP3_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-OP3_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-OP4_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-OP4_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-OP5_PM-v2.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-OP5_PM-v2.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-OP6_PM-v2.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-OP6_PM-v2.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-OP7_PM-v2.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-OP7_PM-v2.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-OP8_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-OP8_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-OP9_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-OP9_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-PF_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-PF_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-PFcm_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-PFcm_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-PFm_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-PFm_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-PFop_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-PFop_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-PFt_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-PFt_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-PGa_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-PGa_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-PGp_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-PGp_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-STS1_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-STS1_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-STS2_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-STS2_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-TE-1.0_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-TE-1.0_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-TE-1.1_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-TE-1.1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-TE-1.2_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-TE-1.2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-TE-2.1_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-TE-2.1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-TE-2.2_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-TE-2.2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-TE-3_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-TE-3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-TI_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-TI_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-TeI_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-TeI_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-a29_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-a29_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-a30_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-a30_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hIP1_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hIP1_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hIP2_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hIP2_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hIP3_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hIP3_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hIP4_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hIP4_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hIP5_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hIP5_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hIP6_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hIP6_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hIP7_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hIP7_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hIP8_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hIP8_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hOc1_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hOc1_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hOc2_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hOc2_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hOc3d_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hOc3d_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hOc3v_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hOc3v_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hOc4d_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hOc4d_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hOc4la_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hOc4la_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hOc4lp_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hOc4lp_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hOc4v_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hOc4v_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hOc5_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hOc5_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hOc6_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hOc6_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hPO1_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-hPO1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-i29_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-i29_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-i30_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-i30_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-p24ab_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-p24ab_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-p24c_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-p24c_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-p29_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-p29_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-p30_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-p30_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-p32_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-p32_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-s24_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-s24_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-s32_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Area-s32_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_CA1_PM-v11.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_CA1_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_CA2_PM-v11.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_CA2_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_CA3_PM-v11.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_CA3_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_CM_PM-v6.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_CM_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Ch-123_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Ch-123_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Ch-4_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Ch-4_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_DG_PM-v11.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_DG_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Dorsal-Dentate-Nucleus_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Dorsal-Dentate-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Entorhinal-Cortex_PM-v11.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Entorhinal-Cortex_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Fastigial-Nucleus_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Fastigial-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Frontal-II_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Frontal-II_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Frontal-I_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Frontal-I_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Frontal-to-Occipital_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Frontal-to-Occipital_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Frontal-to-Temporal_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Frontal-to-Temporal_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_HATA_PM-v11.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_HATA_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_IF_PM-v6.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_IF_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Interposed-Nucleus_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Interposed-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_LB_PM-v6.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_LB_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_MF_PM-v6.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_MF_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_SF_PM-v6.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_SF_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Subiculum_PM-v11.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Subiculum_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Temporal-to-Parietal_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Temporal-to-Parietal_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_VTM_PM-v6.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_VTM_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Ventral-Dentate-Nucleus_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.2-MNI152/JBA_v2.2-MNI152_Ventral-Dentate-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-1_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-1_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-25_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-25_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-2_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-2_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-33_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-33_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-3a_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-3a_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-3b_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-3b_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-44_PM-v7.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-44_PM-v7.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-45_PM-v7.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-45_PM-v7.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-4a_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-4a_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-4p_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-4p_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-5Ci_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-5Ci_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-5L_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-5L_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-5M_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-5M_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-6d1_PM-v4.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-6d1_PM-v4.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-6d2_PM-v4.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-6d2_PM-v4.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-6d3_PM-v4.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-6d3_PM-v4.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-6ma_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-6ma_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-6mp_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-6mp_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-7A_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-7A_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-7PC_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-7PC_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-7P_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-7P_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-FG1_PM-v1.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-FG1_PM-v1.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-FG2_PM-v1.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-FG2_PM-v1.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-FG3_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-FG3_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-FG4_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-FG4_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Fo1_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Fo1_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Fo2_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Fo2_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Fo3_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Fo3_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Fo4_PM-v2.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Fo4_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Fo5_PM-v2.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Fo5_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Fo6_PM-v2.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Fo6_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Fo7_PM-v2.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Fo7_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Fp1_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Fp1_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Fp2_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Fp2_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Ia_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Ia_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Id1_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Id1_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Id2_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Id2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Id3_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Id3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Id4_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Id4_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Id5_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Id5_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Id6_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Id6_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Id7_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Id7_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Ig1_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Ig1_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Ig2_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Ig2_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Ig3_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-Ig3_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-OP1_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-OP1_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-OP2_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-OP2_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-OP3_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-OP3_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-OP4_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-OP4_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-OP5_PM-v2.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-OP5_PM-v2.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-OP6_PM-v2.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-OP6_PM-v2.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-OP7_PM-v2.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-OP7_PM-v2.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-OP8_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-OP8_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-OP9_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-OP9_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-PF_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-PF_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-PFcm_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-PFcm_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-PFm_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-PFm_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-PFop_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-PFop_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-PFt_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-PFt_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-PGa_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-PGa_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-PGp_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-PGp_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-STS1_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-STS1_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-STS2_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-STS2_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-TE-1.0_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-TE-1.0_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-TE-1.1_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-TE-1.1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-TE-1.2_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-TE-1.2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-TE-2.1_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-TE-2.1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-TE-2.2_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-TE-2.2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-TE-3_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-TE-3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-TI_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-TI_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-TeI_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-TeI_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-a29_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-a29_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-a30_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-a30_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hIP1_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hIP1_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hIP2_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hIP2_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hIP3_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hIP3_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hIP4_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hIP4_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hIP5_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hIP5_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hIP6_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hIP6_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hIP7_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hIP7_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hIP8_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hIP8_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hOc1_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hOc1_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hOc2_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hOc2_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hOc3d_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hOc3d_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hOc3v_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hOc3v_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hOc4d_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hOc4d_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hOc4la_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hOc4la_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hOc4lp_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hOc4lp_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hOc4v_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hOc4v_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hOc5_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hOc5_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hOc6_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hOc6_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hPO1_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-hPO1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-i29_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-i29_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-i30_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-i30_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-p24ab_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-p24ab_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-p24c_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-p24c_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-p29_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-p29_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-p30_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-p30_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-p32_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-p32_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-s24_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-s24_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-s32_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Area-s32_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_CA1_PM-v11.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_CA1_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_CA2_PM-v11.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_CA2_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_CA3_PM-v11.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_CA3_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_CM_PM-v6.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_CM_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Ch-123_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Ch-123_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Ch-4_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Ch-4_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_DG_PM-v11.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_DG_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Dorsal-Dentate-Nucleus_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Dorsal-Dentate-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Entorhinal-Cortex_PM-v11.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Entorhinal-Cortex_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Fastigial-Nucleus_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Fastigial-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Frontal-II_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Frontal-II_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Frontal-I_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Frontal-I_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Frontal-to-Occipital_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Frontal-to-Occipital_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Frontal-to-Temporal_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Frontal-to-Temporal_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_HATA_PM-v11.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_HATA_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_IF_PM-v6.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_IF_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Interposed-Nucleus_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Interposed-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_LB_PM-v6.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_LB_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_MF_PM-v6.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_MF_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_SF_PM-v6.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_SF_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Subiculum_PM-v11.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Subiculum_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Temporal-to-Parietal_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Temporal-to-Parietal_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_VTM_PM-v6.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_VTM_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Ventral-Dentate-Nucleus_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-Colin27/JBA_v2.4-Colin27_Ventral-Dentate-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-1_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-1_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-25_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-25_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-2_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-2_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-33_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-33_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-3a_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-3a_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-3b_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-3b_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-44_PM-v7.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-44_PM-v7.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-45_PM-v7.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-45_PM-v7.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-4a_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-4a_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-4p_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-4p_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-5Ci_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-5Ci_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-5L_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-5L_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-5M_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-5M_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-6d1_PM-v4.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-6d1_PM-v4.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-6d2_PM-v4.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-6d2_PM-v4.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-6d3_PM-v4.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-6d3_PM-v4.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-6ma_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-6ma_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-6mp_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-6mp_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-7A_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-7A_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-7PC_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-7PC_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-7P_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-7P_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-FG1_PM-v1.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-FG1_PM-v1.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-FG2_PM-v1.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-FG2_PM-v1.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-FG3_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-FG3_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-FG4_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-FG4_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Fo1_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Fo1_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Fo2_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Fo2_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Fo3_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Fo3_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Fo4_PM-v2.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Fo4_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Fo5_PM-v2.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Fo5_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Fo6_PM-v2.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Fo6_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Fo7_PM-v2.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Fo7_PM-v2.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Fp1_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Fp1_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Fp2_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Fp2_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Ia_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Ia_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Id1_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Id1_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Id2_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Id2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Id3_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Id3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Id4_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Id4_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Id5_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Id5_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Id6_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Id6_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Id7_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Id7_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Ig1_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Ig1_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Ig2_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Ig2_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Ig3_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-Ig3_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-OP1_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-OP1_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-OP2_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-OP2_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-OP3_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-OP3_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-OP4_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-OP4_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-OP5_PM-v2.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-OP5_PM-v2.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-OP6_PM-v2.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-OP6_PM-v2.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-OP7_PM-v2.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-OP7_PM-v2.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-OP8_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-OP8_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-OP9_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-OP9_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-PF_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-PF_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-PFcm_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-PFcm_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-PFm_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-PFm_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-PFop_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-PFop_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-PFt_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-PFt_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-PGa_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-PGa_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-PGp_PM-v9.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-PGp_PM-v9.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-STS1_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-STS1_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-STS2_PM-v3.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-STS2_PM-v3.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-TE-1.0_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-TE-1.0_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-TE-1.1_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-TE-1.1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-TE-1.2_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-TE-1.2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-TE-2.1_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-TE-2.1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-TE-2.2_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-TE-2.2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-TE-3_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-TE-3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-TI_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-TI_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-TeI_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-TeI_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-a29_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-a29_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-a30_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-a30_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hIP1_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hIP1_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hIP2_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hIP2_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hIP3_PM-v8.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hIP3_PM-v8.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hIP4_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hIP4_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hIP5_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hIP5_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hIP6_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hIP6_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hIP7_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hIP7_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hIP8_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hIP8_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hOc1_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hOc1_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hOc2_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hOc2_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hOc3d_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hOc3d_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hOc3v_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hOc3v_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hOc4d_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hOc4d_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hOc4la_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hOc4la_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hOc4lp_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hOc4lp_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hOc4v_PM-v3.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hOc4v_PM-v3.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hOc5_PM-v2.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hOc5_PM-v2.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hOc6_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hOc6_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hPO1_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-hPO1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-i29_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-i29_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-i30_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-i30_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-p24ab_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-p24ab_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-p24c_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-p24c_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-p29_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-p29_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-p30_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-p30_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-p32_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-p32_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-s24_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-s24_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-s32_PM-v16.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Area-s32_PM-v16.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_CA1_PM-v11.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_CA1_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_CA2_PM-v11.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_CA2_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_CA3_PM-v11.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_CA3_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_CM_PM-v6.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_CM_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Ch-123_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Ch-123_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Ch-4_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Ch-4_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_DG_PM-v11.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_DG_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Dorsal-Dentate-Nucleus_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Dorsal-Dentate-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Entorhinal-Cortex_PM-v11.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Entorhinal-Cortex_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Fastigial-Nucleus_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Fastigial-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Frontal-II_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Frontal-II_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Frontal-I_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Frontal-I_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Frontal-to-Occipital_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Frontal-to-Occipital_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Frontal-to-Temporal_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Frontal-to-Temporal_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_HATA_PM-v11.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_HATA_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_IF_PM-v6.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_IF_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Interposed-Nucleus_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Interposed-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_LB_PM-v6.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_LB_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_MF_PM-v6.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_MF_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_SF_PM-v6.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_SF_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Subiculum_PM-v11.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Subiculum_PM-v11.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Temporal-to-Parietal_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Temporal-to-Parietal_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_VTM_PM-v6.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_VTM_PM-v6.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Ventral-Dentate-Nucleus_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.4-MNI152/JBA_v2.4-MNI152_Ventral-Dentate-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-1_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-1_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-25_PM-v18.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-25_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-2_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-2_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-33_PM-v18.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-33_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-3a_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-3a_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-3b_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-3b_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-44_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-44_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-45_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-45_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-4a_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-4a_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-4p_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-4p_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-5Ci_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-5Ci_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-5L_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-5L_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-5M_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-5M_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-6d1_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-6d1_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-6d2_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-6d2_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-6d3_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-6d3_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-6ma_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-6ma_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-6mp_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-6mp_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-7A_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-7A_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-7M_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-7M_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-7PC_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-7PC_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-7P_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-7P_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-FG1_PM-v3.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-FG1_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-FG2_PM-v3.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-FG2_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-FG3_PM-v7.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-FG3_PM-v7.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-FG4_PM-v7.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-FG4_PM-v7.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Fo1_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Fo1_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Fo2_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Fo2_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Fo3_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Fo3_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Fo4_PM-v3.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Fo4_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Fo5_PM-v3.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Fo5_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Fo6_PM-v3.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Fo6_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Fo7_PM-v3.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Fo7_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Fp1_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Fp1_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Fp2_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Fp2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Ia_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Ia_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Id1_PM-v14.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Id1_PM-v14.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Id2_PM-v8.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Id2_PM-v8.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Id3_PM-v8.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Id3_PM-v8.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Id4_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Id4_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Id5_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Id5_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Id6_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Id6_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Id7_PM-v7.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Id7_PM-v7.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Ig1_PM-v14.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Ig1_PM-v14.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Ig2_PM-v14.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Ig2_PM-v14.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Ig3_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-Ig3_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-OP1_PM-v12.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-OP1_PM-v12.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-OP2_PM-v12.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-OP2_PM-v12.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-OP3_PM-v12.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-OP3_PM-v12.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-OP4_PM-v12.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-OP4_PM-v12.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-OP5_PM-v3.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-OP5_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-OP6_PM-v3.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-OP6_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-OP7_PM-v3.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-OP7_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-OP8_PM-v6.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-OP8_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-OP9_PM-v6.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-OP9_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-PF_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-PF_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-PFcm_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-PFcm_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-PFm_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-PFm_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-PFop_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-PFop_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-PFt_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-PFt_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-PGa_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-PGa_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-PGp_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-PGp_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-STS1_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-STS1_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-STS2_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-STS2_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-TE-1.0_PM-v6.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-TE-1.0_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-TE-1.1_PM-v6.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-TE-1.1_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-TE-1.2_PM-v6.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-TE-1.2_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-TE-2.1_PM-v6.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-TE-2.1_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-TE-2.2_PM-v6.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-TE-2.2_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-TE-3_PM-v6.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-TE-3_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-TI_PM-v6.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-TI_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-TeI_PM-v6.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-TeI_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hIP1_PM-v7.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hIP1_PM-v7.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hIP2_PM-v7.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hIP2_PM-v7.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hIP3_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hIP3_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hIP4_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hIP4_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hIP5_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hIP5_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hIP6_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hIP6_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hIP7_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hIP7_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hIP8_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hIP8_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hOc1_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hOc1_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hOc2_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hOc2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hOc3d_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hOc3d_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hOc3v_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hOc3v_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hOc4d_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hOc4d_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hOc4la_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hOc4la_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hOc4lp_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hOc4lp_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hOc4v_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hOc4v_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hOc5_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hOc5_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hOc6_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hOc6_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hPO1_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-hPO1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-p24ab_PM-v18.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-p24ab_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-p24c_PM-v18.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-p24c_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-p32_PM-v18.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-p32_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-s24_PM-v18.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-s24_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-s32_PM-v18.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Area-s32_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_CA1_PM-v13.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_CA1_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_CA2_PM-v13.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_CA2_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_CA3_PM-v13.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_CA3_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_CM_PM-v8.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_CM_PM-v8.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Ch-123_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Ch-123_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Ch-4_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Ch-4_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_DG_PM-v13.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_DG_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Dorsal-Dentate-Nucleus_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Dorsal-Dentate-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Entorhinal-Cortex_PM-v13.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Entorhinal-Cortex_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Fastigial-Nucleus_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Fastigial-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Frontal-II_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Frontal-II_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Frontal-I_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Frontal-I_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Frontal-to-Occipital_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Frontal-to-Occipital_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Frontal-to-Temporal_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Frontal-to-Temporal_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_HATA_PM-v13.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_HATA_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_HC-Transsubiculum_PM-v13.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_HC-Transsubiculum_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_IF_PM-v8.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_IF_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Interposed-Nucleus_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Interposed-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_LB_PM-v8.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_LB_PM-v8.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_MF_PM-v8.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_MF_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_SF_PM-v8.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_SF_PM-v8.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Subiculum.PaS_PM-v13.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Subiculum.PaS_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Subiculum.PreS_PM-v13.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Subiculum.PreS_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Subiculum.ProS_PM-v13.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Subiculum.ProS_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Subiculum.Sub_PM-v13.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Subiculum.Sub_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Temporal-to-Parietal_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Temporal-to-Parietal_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_VTM_PM-v8.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_VTM_PM-v8.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Ventral-Dentate-Nucleus_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-Colin27/JBA_v2.5-Colin27_Ventral-Dentate-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-1_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-1_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-25_PM-v18.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-25_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-2_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-2_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-33_PM-v18.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-33_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-3a_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-3a_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-3b_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-3b_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-44_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-44_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-45_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-45_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-4a_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-4a_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-4p_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-4p_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-5Ci_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-5Ci_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-5L_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-5L_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-5M_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-5M_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-6d1_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-6d1_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-6d2_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-6d2_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-6d3_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-6d3_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-6ma_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-6ma_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-6mp_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-6mp_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-7A_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-7A_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-7M_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-7M_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-7PC_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-7PC_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-7P_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-7P_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-FG1_PM-v3.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-FG1_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-FG2_PM-v3.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-FG2_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-FG3_PM-v7.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-FG3_PM-v7.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-FG4_PM-v7.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-FG4_PM-v7.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Fo1_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Fo1_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Fo2_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Fo2_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Fo3_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Fo3_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Fo4_PM-v3.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Fo4_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Fo5_PM-v3.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Fo5_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Fo6_PM-v3.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Fo6_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Fo7_PM-v3.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Fo7_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Fp1_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Fp1_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Fp2_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Fp2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Ia_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Ia_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Id1_PM-v14.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Id1_PM-v14.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Id2_PM-v8.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Id2_PM-v8.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Id3_PM-v8.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Id3_PM-v8.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Id4_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Id4_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Id5_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Id5_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Id6_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Id6_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Id7_PM-v7.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Id7_PM-v7.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Ig1_PM-v14.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Ig1_PM-v14.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Ig2_PM-v14.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Ig2_PM-v14.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Ig3_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-Ig3_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-OP1_PM-v12.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-OP1_PM-v12.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-OP2_PM-v12.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-OP2_PM-v12.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-OP3_PM-v12.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-OP3_PM-v12.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-OP4_PM-v12.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-OP4_PM-v12.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-OP5_PM-v3.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-OP5_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-OP6_PM-v3.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-OP6_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-OP7_PM-v3.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-OP7_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-OP8_PM-v6.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-OP8_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-OP9_PM-v6.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-OP9_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-PF_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-PF_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-PFcm_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-PFcm_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-PFm_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-PFm_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-PFop_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-PFop_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-PFt_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-PFt_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-PGa_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-PGa_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-PGp_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-PGp_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-STS1_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-STS1_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-STS2_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-STS2_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-TE-1.0_PM-v6.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-TE-1.0_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-TE-1.1_PM-v6.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-TE-1.1_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-TE-1.2_PM-v6.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-TE-1.2_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-TE-2.1_PM-v6.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-TE-2.1_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-TE-2.2_PM-v6.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-TE-2.2_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-TE-3_PM-v6.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-TE-3_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-TI_PM-v6.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-TI_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-TeI_PM-v6.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-TeI_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hIP1_PM-v7.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hIP1_PM-v7.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hIP2_PM-v7.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hIP2_PM-v7.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hIP3_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hIP3_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hIP4_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hIP4_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hIP5_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hIP5_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hIP6_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hIP6_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hIP7_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hIP7_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hIP8_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hIP8_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hOc1_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hOc1_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hOc2_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hOc2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hOc3d_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hOc3d_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hOc3v_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hOc3v_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hOc4d_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hOc4d_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hOc4la_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hOc4la_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hOc4lp_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hOc4lp_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hOc4v_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hOc4v_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hOc5_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hOc5_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hOc6_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hOc6_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hPO1_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-hPO1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-p24ab_PM-v18.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-p24ab_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-p24c_PM-v18.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-p24c_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-p32_PM-v18.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-p32_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-s24_PM-v18.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-s24_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-s32_PM-v18.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Area-s32_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_CA1_PM-v13.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_CA1_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_CA2_PM-v13.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_CA2_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_CA3_PM-v13.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_CA3_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_CM_PM-v8.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_CM_PM-v8.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Ch-123_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Ch-123_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Ch-4_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Ch-4_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_DG_PM-v13.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_DG_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Dorsal-Dentate-Nucleus_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Dorsal-Dentate-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Entorhinal-Cortex_PM-v13.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Entorhinal-Cortex_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Fastigial-Nucleus_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Fastigial-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Frontal-II_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Frontal-II_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Frontal-I_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Frontal-I_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Frontal-to-Occipital_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Frontal-to-Occipital_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Frontal-to-Temporal_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Frontal-to-Temporal_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_HATA_PM-v13.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_HATA_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_HC-Transsubiculum_PM-v13.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_HC-Transsubiculum_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_IF_PM-v8.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_IF_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Interposed-Nucleus_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Interposed-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_LB_PM-v8.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_LB_PM-v8.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_MF_PM-v8.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_MF_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_SF_PM-v8.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_SF_PM-v8.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Subiculum.PaS_PM-v13.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Subiculum.PaS_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Subiculum.PreS_PM-v13.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Subiculum.PreS_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Subiculum.ProS_PM-v13.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Subiculum.ProS_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Subiculum.Sub_PM-v13.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Subiculum.Sub_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Temporal-to-Parietal_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Temporal-to-Parietal_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_VTM_PM-v8.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_VTM_PM-v8.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Ventral-Dentate-Nucleus_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.5-MNI152/JBA_v2.5-MNI152_Ventral-Dentate-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-1_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-1_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-25_PM-v18.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-25_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-2_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-2_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-33_PM-v18.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-33_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-3a_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-3a_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-3b_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-3b_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-44_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-44_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-45_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-45_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-4a_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-4a_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-4p_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-4p_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-5Ci_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-5Ci_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-5L_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-5L_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-5M_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-5M_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-6d1_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-6d1_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-6d2_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-6d2_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-6d3_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-6d3_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-6ma_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-6ma_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-6mp_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-6mp_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-7A_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-7A_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-7M_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-7M_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-7PC_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-7PC_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-7P_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-7P_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-FG1_PM-v3.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-FG1_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-FG2_PM-v3.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-FG2_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-FG3_PM-v7.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-FG3_PM-v7.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-FG4_PM-v7.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-FG4_PM-v7.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Fo1_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Fo1_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Fo2_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Fo2_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Fo3_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Fo3_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Fo4_PM-v3.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Fo4_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Fo5_PM-v3.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Fo5_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Fo6_PM-v3.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Fo6_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Fo7_PM-v3.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Fo7_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Fp1_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Fp1_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Fp2_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Fp2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Ia_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Ia_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Id1_PM-v14.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Id1_PM-v14.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Id2_PM-v8.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Id2_PM-v8.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Id3_PM-v8.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Id3_PM-v8.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Id4_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Id4_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Id5_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Id5_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Id6_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Id6_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Id7_PM-v7.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Id7_PM-v7.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Ig1_PM-v14.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Ig1_PM-v14.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Ig2_PM-v14.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Ig2_PM-v14.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Ig3_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-Ig3_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-OP1_PM-v12.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-OP1_PM-v12.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-OP2_PM-v12.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-OP2_PM-v12.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-OP3_PM-v12.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-OP3_PM-v12.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-OP4_PM-v12.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-OP4_PM-v12.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-OP5_PM-v3.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-OP5_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-OP6_PM-v3.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-OP6_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-OP7_PM-v3.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-OP7_PM-v3.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-OP8_PM-v6.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-OP8_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-OP9_PM-v6.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-OP9_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-PF_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-PF_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-PFcm_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-PFcm_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-PFm_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-PFm_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-PFop_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-PFop_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-PFt_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-PFt_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-PGa_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-PGa_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-PGp_PM-v11.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-PGp_PM-v11.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-STS1_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-STS1_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-STS2_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-STS2_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-TE-1.0_PM-v6.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-TE-1.0_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-TE-1.1_PM-v6.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-TE-1.1_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-TE-1.2_PM-v6.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-TE-1.2_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-TE-2.1_PM-v6.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-TE-2.1_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-TE-2.2_PM-v6.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-TE-2.2_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-TE-3_PM-v6.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-TE-3_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-TI_PM-v6.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-TI_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-TeI_PM-v6.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-TeI_PM-v6.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hIP1_PM-v7.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hIP1_PM-v7.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hIP2_PM-v7.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hIP2_PM-v7.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hIP3_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hIP3_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hIP4_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hIP4_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hIP5_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hIP5_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hIP6_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hIP6_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hIP7_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hIP7_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hIP8_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hIP8_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hOc1_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hOc1_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hOc2_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hOc2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hOc3d_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hOc3d_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hOc3v_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hOc3v_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hOc4d_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hOc4d_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hOc4la_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hOc4la_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hOc4lp_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hOc4lp_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hOc4v_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hOc4v_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hOc5_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hOc5_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hOc6_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hOc6_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hPO1_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-hPO1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-p24ab_PM-v18.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-p24ab_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-p24c_PM-v18.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-p24c_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-p32_PM-v18.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-p32_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-s24_PM-v18.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-s24_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-s32_PM-v18.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Area-s32_PM-v18.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_CA1_PM-v13.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_CA1_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_CA2_PM-v13.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_CA2_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_CA3_PM-v13.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_CA3_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_CM_PM-v8.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_CM_PM-v8.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Ch-123_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Ch-123_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Ch-4_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Ch-4_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_DG_PM-v13.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_DG_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Dorsal-Dentate-Nucleus_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Dorsal-Dentate-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Entorhinal-Cortex_PM-v13.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Entorhinal-Cortex_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Fastigial-Nucleus_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Fastigial-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Frontal-II_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Frontal-II_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Frontal-I_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Frontal-I_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Frontal-to-Occipital_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Frontal-to-Occipital_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Frontal-to-Temporal_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Frontal-to-Temporal_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_HATA_PM-v13.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_HATA_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_HC-Transsubiculum_PM-v13.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_HC-Transsubiculum_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_IF_PM-v8.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_IF_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Interposed-Nucleus_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Interposed-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_LB_PM-v8.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_LB_PM-v8.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_MF_PM-v8.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_MF_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_SF_PM-v8.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_SF_PM-v8.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Subiculum.PaS_PM-v13.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Subiculum.PaS_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Subiculum.PreS_PM-v13.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Subiculum.PreS_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Subiculum.ProS_PM-v13.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Subiculum.ProS_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Subiculum.Sub_PM-v13.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Subiculum.Sub_PM-v13.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Temporal-to-Parietal_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Temporal-to-Parietal_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_VTM_PM-v8.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_VTM_PM-v8.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Ventral-Dentate-Nucleus_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.6-MNI152/JBA_v2.6-MNI152_Ventral-Dentate-Nucleus_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-6d1_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-6d1_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-6d2_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-6d2_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-6d3_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-6d3_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-6ma_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-6ma_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-MFG1_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-MFG1_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-MFG2_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-MFG2_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-SFS1_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-SFS1_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-SFS2_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-SFS2_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-STS1_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-STS1_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-STS2_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-STS2_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-TE-1.0_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-TE-1.0_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-TE-1.1_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-TE-1.1_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-TE-1.2_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-TE-1.2_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-TE-3_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-TE-3_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hIP4_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hIP4_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hIP5_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hIP5_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hIP6_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hIP6_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hIP7_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hIP7_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hIP8_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hIP8_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hOc1_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hOc1_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hOc2_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hOc2_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hOc3v_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hOc3v_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hOc5_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hOc5_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hOc6_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hOc6_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hPO1_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Area-hPO1_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_CGL.lam1_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_CGL.lam1_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_CGL.lam2_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_CGL.lam2_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_CGL.lam3_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_CGL.lam3_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_CGL.lam4_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_CGL.lam4_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_CGL.lam5_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_CGL.lam5_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_CGL.lam6_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_CGL.lam6_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_CGM.CGMd_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_CGM.CGMd_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_CGM.CGMm_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_CGM.CGMm_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_CGM.CGMv_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_CGM.CGMv_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Entorhinal-Cortex_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-BigBrain/JBA_v2.9-BigBrain_Entorhinal-Cortex_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-1_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-1_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-25_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-25_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-2_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-33_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-33_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-3a_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-3a_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-3b_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-3b_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-44_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-44_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-45_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-45_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-4a_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-4a_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-4p_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-4p_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-5Ci_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-5Ci_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-5L_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-5L_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-5M_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-5M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-6d1_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-6d1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-6d2_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-6d2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-6d3_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-6d3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-6ma_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-6ma_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-6mp_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-6mp_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-7A_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-7A_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-7M_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-7M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-7PC_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-7PC_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-7P_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-7P_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-8d1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-8d1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-8d2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-8d2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-8v1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-8v1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-8v2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-8v2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-CoS1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-CoS1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-FG1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-FG1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-FG2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-FG2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-FG3_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-FG3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-FG4_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-FG4_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Fo1_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Fo1_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Fo2_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Fo2_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Fo3_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Fo3_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Fo4_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Fo4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Fo5_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Fo5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Fo6_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Fo6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Fo7_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Fo7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Fp1_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Fp1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Fp2_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Fp2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-IFJ1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-IFJ1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-IFJ2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-IFJ2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-IFS1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-IFS1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-IFS2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-IFS2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-IFS3_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-IFS3_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-IFS4_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-IFS4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Ia1_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Ia1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Ia2_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Ia2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Ia3_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Ia3_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Id10_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Id10_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Id1_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Id1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Id2_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Id2_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Id3_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Id3_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Id4_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Id4_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Id5_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Id5_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Id6_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Id6_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Id7_PM-v8.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Id7_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Id8_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Id8_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Id9_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Id9_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Ig1_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Ig1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Ig2_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Ig2_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Ig3_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Ig3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-OP1_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-OP1_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-OP2_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-OP2_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-OP3_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-OP3_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-OP4_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-OP4_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-OP5_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-OP5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-OP6_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-OP6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-OP7_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-OP7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-OP8_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-OP8_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-OP9_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-OP9_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-PF_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-PF_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-PFcm_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-PFcm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-PFm_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-PFm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-PFop_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-PFop_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-PFt_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-PFt_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-PGa_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-PGa_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-PGp_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-PGp_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Ph1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Ph1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Ph2_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Ph2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Ph3_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-Ph3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-STS1_PM-v5.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-STS1_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-STS2_PM-v5.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-STS2_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-TE-1.0_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-TE-1.0_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-TE-1.1_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-TE-1.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-TE-1.2_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-TE-1.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-TE-2.1_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-TE-2.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-TE-2.2_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-TE-2.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-TE-3_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-TE-3_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-TI_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-TI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-TPJ_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-TPJ_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-TeI_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-TeI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hIP1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hIP1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hIP2_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hIP2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hIP3_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hIP3_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hIP4_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hIP4_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hIP5_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hIP5_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hIP6_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hIP6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hIP7_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hIP7_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hIP8_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hIP8_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hOc1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hOc1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hOc2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hOc2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hOc3d_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hOc3d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hOc3v_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hOc3v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hOc4d_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hOc4d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hOc4la_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hOc4la_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hOc4lp_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hOc4lp_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hOc4v_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hOc4v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hOc5_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hOc5_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hOc6_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hOc6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hPO1_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-hPO1_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-p24ab_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-p24ab_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-p24c_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-p24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-p32_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-p32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-s24_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-s24_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-s32_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Area-s32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_BST_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_BST_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_CA1_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_CA1_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_CA2_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_CA2_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_CA3_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_CA3_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_CGL_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_CGL_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_CGM_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_CGM_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_CM_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_CM_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Ch-123_PM-v4.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Ch-123_PM-v4.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Ch-4_PM-v4.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Ch-4_PM-v4.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_DG_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_DG_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Dorsal-Dentate-Nucleus_PM-v6.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Dorsal-Dentate-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Entorhinal-Cortex_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Entorhinal-Cortex_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Fastigial-Nucleus_PM-v6.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Fastigial-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Frontal-II_PM-v11.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Frontal-II_PM-v11.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Frontal-I_PM-v11.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Frontal-I_PM-v11.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Frontal-to-Occipital_PM-v11.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Frontal-to-Occipital_PM-v11.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Frontal-to-Temporal-II_PM-v11.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Frontal-to-Temporal-II_PM-v11.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Frontal-to-Temporal-I_PM-v11.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Frontal-to-Temporal-I_PM-v11.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_HATA_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_HATA_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_HC-Transsubiculum_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_HC-Transsubiculum_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_IF_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_IF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Interposed-Nucleus_PM-v6.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Interposed-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_LB_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_LB_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_MF_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_MF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_SF_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_SF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Subiculum.PaS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Subiculum.PaS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Subiculum.PreS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Subiculum.PreS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Subiculum.ProS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Subiculum.ProS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Subiculum.Sub_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Subiculum.Sub_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Temporal-to-Parietal_PM-v11.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Temporal-to-Parietal_PM-v11.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_VTM_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_VTM_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Ventral-Dentate-Nucleus_PM-v6.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-Colin27/JBA_v2.9-Colin27_Ventral-Dentate-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-1_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-1_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-25_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-25_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-2_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-33_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-33_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-3a_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-3a_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-3b_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-3b_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-44_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-44_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-45_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-45_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-4a_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-4a_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-4p_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-4p_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-5Ci_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-5Ci_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-5L_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-5L_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-5M_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-5M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-6d1_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-6d1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-6d2_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-6d2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-6d3_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-6d3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-6ma_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-6ma_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-6mp_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-6mp_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-7A_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-7A_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-7M_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-7M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-7PC_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-7PC_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-7P_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-7P_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-8d1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-8d1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-8d2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-8d2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-8v1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-8v1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-8v2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-8v2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-CoS1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-CoS1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-FG1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-FG1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-FG2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-FG2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-FG3_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-FG3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-FG4_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-FG4_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Fo1_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Fo1_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Fo2_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Fo2_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Fo3_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Fo3_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Fo4_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Fo4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Fo5_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Fo5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Fo6_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Fo6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Fo7_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Fo7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Fp1_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Fp1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Fp2_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Fp2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-IFJ1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-IFJ1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-IFJ2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-IFJ2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-IFS1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-IFS1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-IFS2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-IFS2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-IFS3_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-IFS3_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-IFS4_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-IFS4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Ia1_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Ia1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Ia2_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Ia2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Ia3_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Ia3_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Id10_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Id10_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Id1_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Id1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Id2_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Id2_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Id3_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Id3_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Id4_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Id4_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Id5_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Id5_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Id6_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Id6_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Id7_PM-v8.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Id7_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Id8_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Id8_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Id9_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Id9_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Ig1_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Ig1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Ig2_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Ig2_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Ig3_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Ig3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-OP1_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-OP1_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-OP2_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-OP2_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-OP3_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-OP3_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-OP4_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-OP4_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-OP5_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-OP5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-OP6_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-OP6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-OP7_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-OP7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-OP8_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-OP8_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-OP9_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-OP9_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-PF_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-PF_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-PFcm_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-PFcm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-PFm_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-PFm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-PFop_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-PFop_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-PFt_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-PFt_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-PGa_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-PGa_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-PGp_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-PGp_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Ph1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Ph1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Ph2_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Ph2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Ph3_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-Ph3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-STS1_PM-v5.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-STS1_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-STS2_PM-v5.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-STS2_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-TE-1.0_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-TE-1.0_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-TE-1.1_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-TE-1.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-TE-1.2_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-TE-1.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-TE-2.1_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-TE-2.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-TE-2.2_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-TE-2.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-TE-3_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-TE-3_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-TI_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-TI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-TPJ_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-TPJ_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-TeI_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-TeI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hIP1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hIP1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hIP2_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hIP2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hIP3_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hIP3_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hIP4_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hIP4_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hIP5_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hIP5_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hIP6_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hIP6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hIP7_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hIP7_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hIP8_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hIP8_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hOc1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hOc1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hOc2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hOc2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hOc3d_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hOc3d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hOc3v_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hOc3v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hOc4d_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hOc4d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hOc4la_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hOc4la_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hOc4lp_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hOc4lp_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hOc4v_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hOc4v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hOc5_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hOc5_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hOc6_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hOc6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hPO1_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-hPO1_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-p24ab_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-p24ab_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-p24c_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-p24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-p32_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-p32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-s24_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-s24_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-s32_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Area-s32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_BST_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_BST_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_CA1_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_CA1_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_CA2_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_CA2_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_CA3_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_CA3_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_CGL_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_CGL_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_CGM_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_CGM_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_CM_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_CM_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Ch-123_PM-v4.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Ch-123_PM-v4.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Ch-4_PM-v4.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Ch-4_PM-v4.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_DG_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_DG_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Dorsal-Dentate-Nucleus_PM-v6.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Dorsal-Dentate-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Entorhinal-Cortex_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Entorhinal-Cortex_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Fastigial-Nucleus_PM-v6.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Fastigial-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Frontal-II_PM-v11.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Frontal-II_PM-v11.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Frontal-I_PM-v11.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Frontal-I_PM-v11.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Frontal-to-Occipital_PM-v11.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Frontal-to-Occipital_PM-v11.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Frontal-to-Temporal-II_PM-v11.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Frontal-to-Temporal-II_PM-v11.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Frontal-to-Temporal-I_PM-v11.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Frontal-to-Temporal-I_PM-v11.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_HATA_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_HATA_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_HC-Transsubiculum_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_HC-Transsubiculum_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_IF_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_IF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Interposed-Nucleus_PM-v6.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Interposed-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_LB_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_LB_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_MF_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_MF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_SF_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_SF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Subiculum.PaS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Subiculum.PaS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Subiculum.PreS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Subiculum.PreS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Subiculum.ProS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Subiculum.ProS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Subiculum.Sub_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Subiculum.Sub_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Temporal-to-Parietal_PM-v11.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Temporal-to-Parietal_PM-v11.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_VTM_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_VTM_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Ventral-Dentate-Nucleus_PM-v6.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-MNI152/JBA_v2.9-MNI152_Ventral-Dentate-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-1_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-1_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-25_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-25_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-2_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-33_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-33_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-3a_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-3a_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-3b_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-3b_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-44_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-44_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-45_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-45_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-4a_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-4a_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-4p_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-4p_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-5Ci_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-5Ci_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-5L_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-5L_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-5M_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-5M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-6d1_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-6d1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-6d2_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-6d2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-6d3_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-6d3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-6ma_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-6ma_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-6mp_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-6mp_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-7A_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-7A_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-7M_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-7M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-7PC_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-7PC_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-7P_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-7P_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-8d1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-8d1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-8d2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-8d2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-8v1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-8v1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-8v2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-8v2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-CoS1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-CoS1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-FG1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-FG1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-FG2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-FG2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-FG3_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-FG3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-FG4_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-FG4_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Fo1_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Fo1_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Fo2_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Fo2_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Fo3_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Fo3_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Fo4_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Fo4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Fo5_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Fo5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Fo6_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Fo6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Fo7_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Fo7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Fp1_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Fp1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Fp2_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Fp2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-IFJ1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-IFJ1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-IFJ2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-IFJ2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-IFS1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-IFS1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-IFS2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-IFS2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-IFS3_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-IFS3_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-IFS4_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-IFS4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Ia1_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Ia1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Ia2_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Ia2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Ia3_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Ia3_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Id10_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Id10_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Id1_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Id1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Id2_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Id2_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Id3_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Id3_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Id4_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Id4_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Id5_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Id5_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Id6_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Id6_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Id7_PM-v8.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Id7_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Id8_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Id8_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Id9_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Id9_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Ig1_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Ig1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Ig2_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Ig2_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Ig3_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Ig3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-OP1_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-OP1_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-OP2_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-OP2_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-OP3_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-OP3_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-OP4_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-OP4_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-OP5_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-OP5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-OP6_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-OP6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-OP7_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-OP7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-OP8_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-OP8_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-OP9_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-OP9_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-PF_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-PF_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-PFcm_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-PFcm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-PFm_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-PFm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-PFop_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-PFop_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-PFt_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-PFt_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-PGa_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-PGa_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-PGp_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-PGp_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Ph1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Ph1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Ph2_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Ph2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Ph3_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-Ph3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-STS1_PM-v5.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-STS1_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-STS2_PM-v5.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-STS2_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-TE-1.0_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-TE-1.0_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-TE-1.1_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-TE-1.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-TE-1.2_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-TE-1.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-TE-2.1_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-TE-2.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-TE-2.2_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-TE-2.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-TE-3_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-TE-3_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-TI_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-TI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-TPJ_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-TPJ_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-TeI_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-TeI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hIP1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hIP1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hIP2_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hIP2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hIP3_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hIP3_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hIP4_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hIP4_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hIP5_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hIP5_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hIP6_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hIP6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hIP7_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hIP7_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hIP8_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hIP8_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hOc1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hOc1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hOc2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hOc2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hOc3d_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hOc3d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hOc3v_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hOc3v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hOc4d_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hOc4d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hOc4la_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hOc4la_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hOc4lp_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hOc4lp_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hOc4v_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hOc4v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hOc5_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hOc5_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hOc6_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hOc6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hPO1_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-hPO1_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-p24ab_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-p24ab_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-p24c_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-p24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-p32_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-p32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-s24_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-s24_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-s32_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Area-s32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_CA1_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_CA1_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_CA2_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_CA2_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_CA3_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_CA3_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_CGL_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_CGL_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_CGM_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_CGM_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_DG_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_DG_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Entorhinal-Cortex_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Entorhinal-Cortex_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Frontal-II_PM-v11.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Frontal-II_PM-v11.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Frontal-I_PM-v11.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Frontal-I_PM-v11.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Frontal-to-Occipital_PM-v11.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Frontal-to-Occipital_PM-v11.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Frontal-to-Temporal-II_PM-v11.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Frontal-to-Temporal-II_PM-v11.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Frontal-to-Temporal-I_PM-v11.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Frontal-to-Temporal-I_PM-v11.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_HATA_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_HATA_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_HC-Transsubiculum_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_HC-Transsubiculum_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Subiculum.PaS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Subiculum.PaS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Subiculum.PreS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Subiculum.PreS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Subiculum.ProS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Subiculum.ProS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Subiculum.Sub_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Subiculum.Sub_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Temporal-to-Parietal_PM-v11.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v2.9-fsaverage/JBA_v2.9-fsaverage_Temporal-to-Parietal_PM-v11.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-6d1_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-6d1_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-6d2_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-6d2_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-6d3_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-6d3_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-6ma_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-6ma_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-MFG1_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-MFG1_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-MFG2_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-MFG2_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-SFS1_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-SFS1_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-SFS2_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-SFS2_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-STS1_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-STS1_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-STS2_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-STS2_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-TE-1.0_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-TE-1.0_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-TE-1.1_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-TE-1.1_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-TE-1.2_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-TE-1.2_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-TE-3_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-TE-3_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hIP4_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hIP4_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hIP5_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hIP5_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hIP6_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hIP6_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hIP7_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hIP7_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hIP8_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hIP8_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hOc1_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hOc1_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hOc2_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hOc2_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hOc3v_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hOc3v_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hOc5_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hOc5_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hOc6_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hOc6_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hPO1_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Area-hPO1_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_CGL.lam1_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_CGL.lam1_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_CGL.lam2_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_CGL.lam2_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_CGL.lam3_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_CGL.lam3_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_CGL.lam4_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_CGL.lam4_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_CGL.lam5_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_CGL.lam5_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_CGL.lam6_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_CGL.lam6_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_CGM.CGMd_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_CGM.CGMd_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_CGM.CGMm_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_CGM.CGMm_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_CGM.CGMv_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_CGM.CGMv_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Entorhinal-Cortex_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-BigBrain/JBA_v3.0-BigBrain_Entorhinal-Cortex_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_AcbL_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_AcbL_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_AcbM_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_AcbM_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-1_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-1_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-25.25a_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-25.25a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-25.25p_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-25.25p_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-25_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-25_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-2_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-33_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-33_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-3a_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-3a_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-3b_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-3b_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-44_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-44_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-45_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-45_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-4a_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-4a_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-4p_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-4p_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-5Ci_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-5Ci_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-5L_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-5L_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-5M_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-5M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-6d1_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-6d1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-6d2_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-6d2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-6d3_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-6d3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-6ma_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-6ma_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-6mp_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-6mp_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-7A_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-7A_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-7M_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-7M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-7PC_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-7PC_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-7P_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-7P_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-8d1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-8d1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-8d2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-8d2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-8v1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-8v1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-8v2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-8v2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-CoS1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-CoS1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-FG1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-FG1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-FG2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-FG2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-FG3_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-FG3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-FG4_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-FG4_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Fo1_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Fo1_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Fo2_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Fo2_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Fo3_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Fo3_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Fo4_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Fo4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Fo5_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Fo5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Fo6_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Fo6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Fo7_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Fo7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Fp1_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Fp1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Fp2_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Fp2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-IFJ1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-IFJ1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-IFJ2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-IFJ2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-IFS1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-IFS1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-IFS2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-IFS2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-IFS3_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-IFS3_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-IFS4_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-IFS4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Ia1_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Ia1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Ia2_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Ia2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Ia3_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Ia3_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Id10_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Id10_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Id1_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Id1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Id2_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Id2_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Id3_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Id3_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Id4_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Id4_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Id5_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Id5_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Id6_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Id6_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Id7_PM-v8.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Id7_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Id8_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Id8_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Id9_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Id9_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Ig1_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Ig1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Ig2_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Ig2_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Ig3_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Ig3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-MFG1_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-MFG1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-MFG2_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-MFG2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-OP1_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-OP1_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-OP2_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-OP2_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-OP3_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-OP3_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-OP4_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-OP4_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-OP5_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-OP5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-OP6_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-OP6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-OP7_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-OP7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-OP8_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-OP8_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-OP9_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-OP9_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-PF_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-PF_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-PFcm_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-PFcm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-PFm_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-PFm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-PFop_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-PFop_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-PFt_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-PFt_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-PGa_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-PGa_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-PGp_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-PGp_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Ph1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Ph1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Ph2_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Ph2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Ph3_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-Ph3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-SFS1_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-SFS1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-SFS2_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-SFS2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-STS1_PM-v5.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-STS1_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-STS2_PM-v5.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-STS2_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-TE-1.0_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-TE-1.0_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-TE-1.1_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-TE-1.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-TE-1.2_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-TE-1.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-TE-2.1_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-TE-2.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-TE-2.2_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-TE-2.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-TE-3_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-TE-3_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-TI_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-TI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-TPJ_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-TPJ_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-TeI_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-TeI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hIP1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hIP1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hIP2_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hIP2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hIP3_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hIP3_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hIP4_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hIP4_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hIP5_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hIP5_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hIP6_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hIP6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hIP7_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hIP7_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hIP8_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hIP8_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hOc1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hOc1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hOc2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hOc2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hOc3d_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hOc3d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hOc3v_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hOc3v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hOc4d_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hOc4d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hOc4la_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hOc4la_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hOc4lp_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hOc4lp_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hOc4v_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hOc4v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hOc5_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hOc5_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hOc6_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hOc6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hPO1_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-hPO1_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-p24ab.p24a_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-p24ab.p24a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-p24ab.p24b_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-p24ab.p24b_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-p24ab_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-p24ab_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-p24c.pd24cd_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-p24c.pd24cd_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-p24c.pd24cv_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-p24c.pd24cv_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-p24c.pv24c_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-p24c.pv24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-p24c_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-p24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-p32_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-p32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-s24.s24a_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-s24.s24a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-s24.s24b_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-s24.s24b_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-s24_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-s24_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-s32_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Area-s32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_BST_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_BST_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_CA1_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_CA1_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_CA2_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_CA2_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_CA3_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_CA3_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_CGL_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_CGL_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_CGM_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_CGM_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_CM.AAA_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_CM.AAA_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_CM.Ce_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_CM.Ce_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_CM.Me_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_CM.Me_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_CM_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_CM_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Ch-123_PM-v4.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Ch-123_PM-v4.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Ch-4_PM-v4.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Ch-4_PM-v4.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_DG_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_DG_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Dorsal-Dentate-Nucleus_PM-v6.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Dorsal-Dentate-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Entorhinal-Cortex_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Entorhinal-Cortex_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Fastigial-Nucleus_PM-v6.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Fastigial-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Frontal-II_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Frontal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Frontal-I_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Frontal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Frontal-to-Occipital_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Frontal-to-Occipital_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Frontal-to-Temporal-II_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Frontal-to-Temporal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Frontal-to-Temporal-I_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Frontal-to-Temporal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_FuCd_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_FuCd_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_FuP_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_FuP_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_HATA_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_HATA_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_HC-Transsubiculum_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_HC-Transsubiculum_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_IF.ice_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_IF.ice_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_IF.iol_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_IF.iol_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_IF.ld_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_IF.ld_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_IF_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_IF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Interposed-Nucleus_PM-v6.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Interposed-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_LB.Bl_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_LB.Bl_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_LB.Bm_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_LB.Bm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_LB.La_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_LB.La_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_LB.Pl_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_LB.Pl_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_LB_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_LB_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_MF.icm_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_MF.icm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_MF.lm_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_MF.lm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_MF_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_MF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_SF.AHi_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_SF.AHi_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_SF.APir_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_SF.APir_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_SF.VCo_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_SF.VCo_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_SF_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_SF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_STN_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_STN_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Subiculum.PaS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Subiculum.PaS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Subiculum.PreS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Subiculum.PreS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Subiculum.ProS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Subiculum.ProS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Subiculum.Sub_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Subiculum.Sub_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Temporal-to-Parietal_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Temporal-to-Parietal_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Terminal-islands_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Terminal-islands_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Tuberculum_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Tuberculum_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_VP_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_VP_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_VTM_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_VTM_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Ventral-Dentate-Nucleus_PM-v6.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-Colin27/JBA_v3.0-Colin27_Ventral-Dentate-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_AcbL_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_AcbL_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_AcbM_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_AcbM_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-1_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-1_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-25.25a_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-25.25a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-25.25p_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-25.25p_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-25_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-25_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-2_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-33_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-33_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-3a_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-3a_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-3b_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-3b_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-44_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-44_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-45_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-45_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-4a_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-4a_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-4p_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-4p_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-5Ci_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-5Ci_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-5L_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-5L_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-5M_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-5M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-6d1_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-6d1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-6d2_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-6d2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-6d3_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-6d3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-6ma_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-6ma_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-6mp_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-6mp_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-7A_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-7A_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-7M_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-7M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-7PC_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-7PC_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-7P_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-7P_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-8d1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-8d1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-8d2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-8d2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-8v1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-8v1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-8v2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-8v2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-CoS1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-CoS1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-FG1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-FG1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-FG2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-FG2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-FG3_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-FG3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-FG4_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-FG4_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Fo1_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Fo1_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Fo2_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Fo2_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Fo3_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Fo3_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Fo4_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Fo4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Fo5_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Fo5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Fo6_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Fo6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Fo7_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Fo7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Fp1_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Fp1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Fp2_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Fp2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-IFJ1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-IFJ1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-IFJ2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-IFJ2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-IFS1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-IFS1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-IFS2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-IFS2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-IFS3_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-IFS3_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-IFS4_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-IFS4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Ia1_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Ia1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Ia2_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Ia2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Ia3_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Ia3_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Id10_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Id10_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Id1_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Id1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Id2_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Id2_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Id3_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Id3_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Id4_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Id4_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Id5_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Id5_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Id6_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Id6_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Id7_PM-v8.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Id7_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Id8_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Id8_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Id9_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Id9_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Ig1_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Ig1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Ig2_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Ig2_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Ig3_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Ig3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-MFG1_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-MFG1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-MFG2_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-MFG2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-OP1_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-OP1_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-OP2_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-OP2_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-OP3_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-OP3_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-OP4_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-OP4_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-OP5_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-OP5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-OP6_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-OP6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-OP7_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-OP7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-OP8_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-OP8_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-OP9_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-OP9_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-PF_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-PF_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-PFcm_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-PFcm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-PFm_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-PFm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-PFop_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-PFop_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-PFt_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-PFt_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-PGa_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-PGa_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-PGp_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-PGp_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Ph1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Ph1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Ph2_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Ph2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Ph3_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-Ph3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-SFS1_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-SFS1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-SFS2_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-SFS2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-STS1_PM-v5.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-STS1_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-STS2_PM-v5.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-STS2_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-TE-1.0_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-TE-1.0_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-TE-1.1_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-TE-1.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-TE-1.2_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-TE-1.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-TE-2.1_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-TE-2.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-TE-2.2_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-TE-2.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-TE-3_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-TE-3_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-TI_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-TI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-TPJ_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-TPJ_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-TeI_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-TeI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hIP1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hIP1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hIP2_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hIP2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hIP3_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hIP3_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hIP4_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hIP4_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hIP5_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hIP5_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hIP6_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hIP6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hIP7_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hIP7_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hIP8_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hIP8_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hOc1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hOc1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hOc2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hOc2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hOc3d_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hOc3d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hOc3v_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hOc3v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hOc4d_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hOc4d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hOc4la_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hOc4la_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hOc4lp_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hOc4lp_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hOc4v_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hOc4v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hOc5_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hOc5_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hOc6_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hOc6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hPO1_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-hPO1_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-p24ab.p24a_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-p24ab.p24a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-p24ab.p24b_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-p24ab.p24b_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-p24ab_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-p24ab_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-p24c.pd24cd_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-p24c.pd24cd_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-p24c.pd24cv_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-p24c.pd24cv_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-p24c.pv24c_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-p24c.pv24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-p24c_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-p24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-p32_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-p32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-s24.s24a_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-s24.s24a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-s24.s24b_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-s24.s24b_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-s24_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-s24_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-s32_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Area-s32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_BST_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_BST_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_CA1_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_CA1_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_CA2_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_CA2_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_CA3_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_CA3_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_CGL_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_CGL_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_CGM_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_CGM_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_CM.AAA_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_CM.AAA_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_CM.Ce_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_CM.Ce_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_CM.Me_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_CM.Me_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_CM_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_CM_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Ch-123_PM-v4.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Ch-123_PM-v4.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Ch-4_PM-v4.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Ch-4_PM-v4.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_DG_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_DG_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Dorsal-Dentate-Nucleus_PM-v6.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Dorsal-Dentate-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Entorhinal-Cortex_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Entorhinal-Cortex_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Fastigial-Nucleus_PM-v6.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Fastigial-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Frontal-II_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Frontal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Frontal-I_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Frontal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Frontal-to-Occipital_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Frontal-to-Occipital_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Frontal-to-Temporal-II_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Frontal-to-Temporal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Frontal-to-Temporal-I_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Frontal-to-Temporal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_FuCd_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_FuCd_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_FuP_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_FuP_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_HATA_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_HATA_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_HC-Transsubiculum_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_HC-Transsubiculum_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_IF.ice_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_IF.ice_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_IF.iol_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_IF.iol_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_IF.ld_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_IF.ld_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_IF_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_IF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Interposed-Nucleus_PM-v6.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Interposed-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_LB.Bl_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_LB.Bl_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_LB.Bm_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_LB.Bm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_LB.La_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_LB.La_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_LB.Pl_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_LB.Pl_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_LB_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_LB_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_MF.icm_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_MF.icm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_MF.lm_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_MF.lm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_MF_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_MF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_SF.AHi_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_SF.AHi_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_SF.APir_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_SF.APir_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_SF.VCo_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_SF.VCo_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_SF_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_SF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_STN_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_STN_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Subiculum.PaS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Subiculum.PaS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Subiculum.PreS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Subiculum.PreS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Subiculum.ProS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Subiculum.ProS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Subiculum.Sub_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Subiculum.Sub_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Temporal-to-Parietal_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Temporal-to-Parietal_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Terminal-islands_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Terminal-islands_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Tuberculum_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Tuberculum_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_VP_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_VP_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_VTM_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_VTM_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Ventral-Dentate-Nucleus_PM-v6.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-MNI152/JBA_v3.0-MNI152_Ventral-Dentate-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-1_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-1_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-25_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-25_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-2_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-33_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-33_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-3a_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-3a_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-3b_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-3b_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-44_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-44_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-45_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-45_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-4a_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-4a_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-4p_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-4p_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-5Ci_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-5Ci_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-5L_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-5L_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-5M_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-5M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-6d1_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-6d1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-6d2_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-6d2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-6d3_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-6d3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-6ma_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-6ma_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-6mp_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-6mp_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-7A_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-7A_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-7M_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-7M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-7PC_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-7PC_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-7P_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-7P_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-8d1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-8d1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-8d2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-8d2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-8v1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-8v1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-8v2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-8v2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-CoS1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-CoS1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-FG1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-FG1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-FG2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-FG2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-FG3_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-FG3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-FG4_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-FG4_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Fo1_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Fo1_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Fo2_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Fo2_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Fo3_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Fo3_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Fo4_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Fo4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Fo5_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Fo5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Fo6_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Fo6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Fo7_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Fo7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Fp1_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Fp1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Fp2_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Fp2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-IFJ1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-IFJ1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-IFJ2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-IFJ2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-IFS1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-IFS1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-IFS2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-IFS2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-IFS3_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-IFS3_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-IFS4_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-IFS4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Ia1_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Ia1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Ia2_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Ia2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Ia3_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Ia3_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Id10_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Id10_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Id1_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Id1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Id2_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Id2_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Id3_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Id3_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Id4_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Id4_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Id5_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Id5_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Id6_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Id6_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Id7_PM-v8.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Id7_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Id8_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Id8_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Id9_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Id9_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Ig1_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Ig1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Ig2_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Ig2_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Ig3_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Ig3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-MFG1_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-MFG1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-MFG2_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-MFG2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-OP1_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-OP1_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-OP2_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-OP2_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-OP3_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-OP3_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-OP4_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-OP4_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-OP5_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-OP5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-OP6_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-OP6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-OP7_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-OP7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-OP8_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-OP8_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-OP9_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-OP9_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-PF_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-PF_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-PFcm_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-PFcm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-PFm_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-PFm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-PFop_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-PFop_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-PFt_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-PFt_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-PGa_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-PGa_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-PGp_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-PGp_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Ph1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Ph1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Ph2_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Ph2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Ph3_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-Ph3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-SFS1_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-SFS1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-SFS2_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-SFS2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-STS1_PM-v5.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-STS1_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-STS2_PM-v5.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-STS2_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-TE-1.0_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-TE-1.0_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-TE-1.1_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-TE-1.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-TE-1.2_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-TE-1.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-TE-2.1_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-TE-2.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-TE-2.2_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-TE-2.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-TE-3_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-TE-3_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-TI_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-TI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-TPJ_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-TPJ_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-TeI_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-TeI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hIP1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hIP1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hIP2_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hIP2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hIP3_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hIP3_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hIP4_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hIP4_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hIP5_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hIP5_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hIP6_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hIP6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hIP7_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hIP7_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hIP8_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hIP8_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hOc1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hOc1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hOc2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hOc2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hOc3d_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hOc3d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hOc3v_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hOc3v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hOc4d_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hOc4d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hOc4la_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hOc4la_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hOc4lp_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hOc4lp_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hOc4v_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hOc4v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hOc5_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hOc5_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hOc6_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hOc6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hPO1_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-hPO1_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-p24ab_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-p24ab_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-p24c_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-p24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-p32_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-p32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-s24_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-s24_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-s32_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Area-s32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_CA1_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_CA1_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_CA2_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_CA2_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_CA3_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_CA3_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_CGL_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_CGL_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_CGM_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_CGM_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_DG_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_DG_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Entorhinal-Cortex_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Entorhinal-Cortex_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Frontal-II_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Frontal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Frontal-I_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Frontal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Frontal-to-Occipital_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Frontal-to-Occipital_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Frontal-to-Temporal-II_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Frontal-to-Temporal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Frontal-to-Temporal-I_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Frontal-to-Temporal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_HATA_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_HATA_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_HC-Transsubiculum_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_HC-Transsubiculum_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Subiculum.PaS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Subiculum.PaS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Subiculum.PreS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Subiculum.PreS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Subiculum.ProS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Subiculum.ProS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Subiculum.Sub_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Subiculum.Sub_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Temporal-to-Parietal_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Temporal-to-Parietal_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Tuberculum_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0-fsaverage/JBA_v3.0-fsaverage_Tuberculum_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-6d1_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-6d1_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-6d2_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-6d2_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-6d3_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-6d3_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-6ma_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-6ma_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-MFG1_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-MFG1_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-MFG2_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-MFG2_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-SFS1_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-SFS1_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-SFS2_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-SFS2_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-STS1_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-STS1_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-STS2_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-STS2_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-TE-1.0_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-TE-1.0_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-TE-1.1_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-TE-1.1_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-TE-1.2_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-TE-1.2_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-TE-3_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-TE-3_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hIP4_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hIP4_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hIP5_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hIP5_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hIP6_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hIP6_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hIP7_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hIP7_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hIP8_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hIP8_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hOc1_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hOc1_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hOc2_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hOc2_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hOc3v_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hOc3v_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hOc5_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hOc5_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hOc6_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hOc6_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hPO1_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Area-hPO1_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_CGL.lam1_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_CGL.lam1_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_CGL.lam2_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_CGL.lam2_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_CGL.lam3_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_CGL.lam3_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_CGL.lam4_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_CGL.lam4_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_CGL.lam5_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_CGL.lam5_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_CGL.lam6_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_CGL.lam6_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_CGM.CGMd_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_CGM.CGMd_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_CGM.CGMm_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_CGM.CGMm_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_CGM.CGMv_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_CGM.CGMv_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Entorhinal-Cortex_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-BigBrain/JBA_v3.0.1-BigBrain_Entorhinal-Cortex_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_AcbL_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_AcbL_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_AcbM_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_AcbM_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-1_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-1_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-25.25a_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-25.25a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-25.25p_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-25.25p_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-25_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-25_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-2_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-33_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-33_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-3a_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-3a_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-3b_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-3b_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-44_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-44_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-45_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-45_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-4a_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-4a_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-4p_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-4p_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-5Ci_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-5Ci_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-5L_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-5L_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-5M_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-5M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-6d1_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-6d1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-6d2_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-6d2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-6d3_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-6d3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-6ma_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-6ma_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-6mp_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-6mp_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-7A_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-7A_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-7M_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-7M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-7PC_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-7PC_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-7P_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-7P_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-8d1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-8d1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-8d2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-8d2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-8v1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-8v1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-8v2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-8v2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-CoS1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-CoS1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-FG1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-FG1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-FG2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-FG2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-FG3_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-FG3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-FG4_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-FG4_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Fo1_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Fo1_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Fo2_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Fo2_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Fo3_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Fo3_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Fo4_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Fo4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Fo5_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Fo5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Fo6_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Fo6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Fo7_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Fo7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Fp1_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Fp1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Fp2_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Fp2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-IFJ1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-IFJ1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-IFJ2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-IFJ2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-IFS1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-IFS1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-IFS2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-IFS2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-IFS3_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-IFS3_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-IFS4_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-IFS4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Ia1_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Ia1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Ia2_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Ia2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Ia3_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Ia3_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Id10_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Id10_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Id1_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Id1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Id2_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Id2_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Id3_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Id3_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Id4_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Id4_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Id5_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Id5_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Id6_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Id6_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Id7_PM-v8.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Id7_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Id8_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Id8_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Id9_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Id9_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Ig1_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Ig1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Ig2_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Ig2_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Ig3_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Ig3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-MFG1_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-MFG1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-MFG2_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-MFG2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-OP1_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-OP1_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-OP2_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-OP2_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-OP3_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-OP3_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-OP4_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-OP4_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-OP5_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-OP5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-OP6_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-OP6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-OP7_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-OP7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-OP8_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-OP8_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-OP9_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-OP9_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-PF_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-PF_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-PFcm_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-PFcm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-PFm_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-PFm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-PFop_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-PFop_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-PFt_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-PFt_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-PGa_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-PGa_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-PGp_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-PGp_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Ph1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Ph1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Ph2_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Ph2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Ph3_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-Ph3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-SFS1_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-SFS1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-SFS2_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-SFS2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-STS1_PM-v5.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-STS1_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-STS2_PM-v5.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-STS2_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-TE-1.0_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-TE-1.0_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-TE-1.1_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-TE-1.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-TE-1.2_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-TE-1.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-TE-2.1_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-TE-2.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-TE-2.2_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-TE-2.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-TE-3_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-TE-3_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-TI_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-TI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-TPJ_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-TPJ_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-TeI_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-TeI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hIP1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hIP1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hIP2_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hIP2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hIP3_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hIP3_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hIP4_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hIP4_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hIP5_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hIP5_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hIP6_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hIP6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hIP7_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hIP7_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hIP8_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hIP8_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hOc1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hOc1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hOc2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hOc2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hOc3d_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hOc3d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hOc3v_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hOc3v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hOc4d_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hOc4d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hOc4la_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hOc4la_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hOc4lp_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hOc4lp_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hOc4v_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hOc4v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hOc5_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hOc5_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hOc6_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hOc6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hPO1_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-hPO1_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-p24ab.p24a_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-p24ab.p24a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-p24ab.p24b_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-p24ab.p24b_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-p24ab_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-p24ab_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-p24c.pd24cd_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-p24c.pd24cd_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-p24c.pd24cv_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-p24c.pd24cv_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-p24c.pv24c_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-p24c.pv24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-p24c_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-p24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-p32_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-p32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-s24.s24a_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-s24.s24a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-s24.s24b_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-s24.s24b_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-s24_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-s24_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-s32_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Area-s32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_BST_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_BST_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_CA1_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_CA1_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_CA2_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_CA2_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_CA3_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_CA3_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_CGL_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_CGL_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_CGM_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_CGM_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_CM.AAA_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_CM.AAA_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_CM.Ce_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_CM.Ce_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_CM.Me_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_CM.Me_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_CM_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_CM_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Ch-123_PM-v4.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Ch-123_PM-v4.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Ch-4_PM-v4.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Ch-4_PM-v4.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_DG_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_DG_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Dorsal-Dentate-Nucleus_PM-v6.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Dorsal-Dentate-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Entorhinal-Cortex_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Entorhinal-Cortex_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Fastigial-Nucleus_PM-v6.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Fastigial-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Frontal-II_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Frontal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Frontal-I_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Frontal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Frontal-to-Occipital_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Frontal-to-Occipital_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Frontal-to-Temporal-II_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Frontal-to-Temporal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Frontal-to-Temporal-I_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Frontal-to-Temporal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_FuCd_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_FuCd_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_FuP_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_FuP_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_HATA_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_HATA_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_HC-Transsubiculum_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_HC-Transsubiculum_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_IF.ice_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_IF.ice_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_IF.iol_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_IF.iol_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_IF.ld_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_IF.ld_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_IF_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_IF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Interposed-Nucleus_PM-v6.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Interposed-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_LB.Bl_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_LB.Bl_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_LB.Bm_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_LB.Bm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_LB.La_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_LB.La_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_LB.Pl_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_LB.Pl_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_LB_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_LB_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_MF.icm_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_MF.icm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_MF.lm_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_MF.lm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_MF_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_MF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_SF.AHi_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_SF.AHi_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_SF.APir_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_SF.APir_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_SF.VCo_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_SF.VCo_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_SF_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_SF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_STN_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_STN_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Subiculum.PaS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Subiculum.PaS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Subiculum.PreS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Subiculum.PreS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Subiculum.ProS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Subiculum.ProS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Subiculum.Sub_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Subiculum.Sub_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Temporal-to-Parietal_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Temporal-to-Parietal_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Terminal-islands_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Terminal-islands_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Tuberculum_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Tuberculum_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_VP_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_VP_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_VTM_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_VTM_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Ventral-Dentate-Nucleus_PM-v6.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-Colin27/JBA_v3.0.1-Colin27_Ventral-Dentate-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_AcbL_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_AcbL_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_AcbM_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_AcbM_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-1_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-1_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-25.25a_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-25.25a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-25.25p_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-25.25p_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-25_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-25_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-2_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-33_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-33_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-3a_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-3a_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-3b_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-3b_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-44_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-44_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-45_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-45_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-4a_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-4a_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-4p_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-4p_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-5Ci_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-5Ci_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-5L_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-5L_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-5M_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-5M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-6d1_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-6d1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-6d2_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-6d2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-6d3_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-6d3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-6ma_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-6ma_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-6mp_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-6mp_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-7A_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-7A_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-7M_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-7M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-7PC_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-7PC_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-7P_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-7P_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-8d1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-8d1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-8d2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-8d2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-8v1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-8v1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-8v2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-8v2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-CoS1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-CoS1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-FG1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-FG1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-FG2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-FG2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-FG3_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-FG3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-FG4_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-FG4_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Fo1_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Fo1_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Fo2_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Fo2_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Fo3_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Fo3_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Fo4_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Fo4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Fo5_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Fo5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Fo6_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Fo6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Fo7_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Fo7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Fp1_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Fp1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Fp2_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Fp2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-IFJ1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-IFJ1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-IFJ2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-IFJ2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-IFS1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-IFS1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-IFS2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-IFS2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-IFS3_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-IFS3_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-IFS4_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-IFS4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Ia1_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Ia1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Ia2_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Ia2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Ia3_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Ia3_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Id10_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Id10_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Id1_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Id1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Id2_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Id2_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Id3_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Id3_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Id4_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Id4_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Id5_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Id5_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Id6_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Id6_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Id7_PM-v8.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Id7_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Id8_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Id8_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Id9_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Id9_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Ig1_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Ig1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Ig2_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Ig2_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Ig3_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Ig3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-MFG1_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-MFG1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-MFG2_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-MFG2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-OP1_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-OP1_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-OP2_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-OP2_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-OP3_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-OP3_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-OP4_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-OP4_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-OP5_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-OP5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-OP6_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-OP6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-OP7_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-OP7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-OP8_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-OP8_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-OP9_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-OP9_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-PF_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-PF_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-PFcm_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-PFcm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-PFm_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-PFm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-PFop_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-PFop_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-PFt_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-PFt_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-PGa_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-PGa_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-PGp_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-PGp_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Ph1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Ph1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Ph2_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Ph2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Ph3_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-Ph3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-SFS1_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-SFS1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-SFS2_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-SFS2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-STS1_PM-v5.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-STS1_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-STS2_PM-v5.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-STS2_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-TE-1.0_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-TE-1.0_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-TE-1.1_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-TE-1.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-TE-1.2_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-TE-1.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-TE-2.1_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-TE-2.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-TE-2.2_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-TE-2.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-TE-3_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-TE-3_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-TI_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-TI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-TPJ_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-TPJ_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-TeI_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-TeI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hIP1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hIP1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hIP2_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hIP2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hIP3_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hIP3_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hIP4_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hIP4_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hIP5_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hIP5_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hIP6_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hIP6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hIP7_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hIP7_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hIP8_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hIP8_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hOc1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hOc1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hOc2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hOc2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hOc3d_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hOc3d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hOc3v_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hOc3v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hOc4d_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hOc4d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hOc4la_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hOc4la_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hOc4lp_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hOc4lp_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hOc4v_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hOc4v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hOc5_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hOc5_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hOc6_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hOc6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hPO1_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-hPO1_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-p24ab.p24a_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-p24ab.p24a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-p24ab.p24b_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-p24ab.p24b_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-p24ab_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-p24ab_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-p24c.pd24cd_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-p24c.pd24cd_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-p24c.pd24cv_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-p24c.pd24cv_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-p24c.pv24c_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-p24c.pv24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-p24c_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-p24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-p32_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-p32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-s24.s24a_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-s24.s24a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-s24.s24b_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-s24.s24b_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-s24_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-s24_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-s32_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Area-s32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_BST_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_BST_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_CA1_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_CA1_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_CA2_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_CA2_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_CA3_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_CA3_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_CGL_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_CGL_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_CGM_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_CGM_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_CM.AAA_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_CM.AAA_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_CM.Ce_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_CM.Ce_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_CM.Me_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_CM.Me_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_CM_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_CM_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Ch-123_PM-v4.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Ch-123_PM-v4.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Ch-4_PM-v4.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Ch-4_PM-v4.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_DG_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_DG_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Dorsal-Dentate-Nucleus_PM-v6.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Dorsal-Dentate-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Entorhinal-Cortex_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Entorhinal-Cortex_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Fastigial-Nucleus_PM-v6.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Fastigial-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Frontal-II_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Frontal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Frontal-I_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Frontal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Frontal-to-Occipital_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Frontal-to-Occipital_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Frontal-to-Temporal-II_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Frontal-to-Temporal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Frontal-to-Temporal-I_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Frontal-to-Temporal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_FuCd_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_FuCd_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_FuP_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_FuP_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_HATA_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_HATA_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_HC-Transsubiculum_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_HC-Transsubiculum_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_IF.ice_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_IF.ice_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_IF.iol_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_IF.iol_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_IF.ld_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_IF.ld_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_IF_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_IF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Interposed-Nucleus_PM-v6.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Interposed-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_LB.Bl_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_LB.Bl_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_LB.Bm_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_LB.Bm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_LB.La_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_LB.La_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_LB.Pl_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_LB.Pl_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_LB_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_LB_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_MF.icm_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_MF.icm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_MF.lm_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_MF.lm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_MF_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_MF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_SF.AHi_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_SF.AHi_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_SF.APir_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_SF.APir_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_SF.VCo_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_SF.VCo_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_SF_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_SF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_STN_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_STN_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Subiculum.PaS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Subiculum.PaS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Subiculum.PreS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Subiculum.PreS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Subiculum.ProS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Subiculum.ProS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Subiculum.Sub_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Subiculum.Sub_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Temporal-to-Parietal_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Temporal-to-Parietal_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Terminal-islands_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Terminal-islands_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Tuberculum_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Tuberculum_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_VP_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_VP_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_VTM_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_VTM_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Ventral-Dentate-Nucleus_PM-v6.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-MNI152/JBA_v3.0.1-MNI152_Ventral-Dentate-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-1_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-1_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-25_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-25_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-2_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-33_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-33_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-3a_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-3a_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-3b_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-3b_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-44_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-44_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-45_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-45_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-4a_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-4a_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-4p_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-4p_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-5Ci_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-5Ci_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-5L_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-5L_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-5M_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-5M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-6d1_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-6d1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-6d2_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-6d2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-6d3_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-6d3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-6ma_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-6ma_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-6mp_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-6mp_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-7A_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-7A_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-7M_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-7M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-7PC_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-7PC_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-7P_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-7P_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-8d1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-8d1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-8d2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-8d2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-8v1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-8v1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-8v2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-8v2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-CoS1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-CoS1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-FG1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-FG1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-FG2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-FG2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-FG3_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-FG3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-FG4_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-FG4_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Fo1_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Fo1_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Fo2_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Fo2_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Fo3_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Fo3_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Fo4_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Fo4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Fo5_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Fo5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Fo6_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Fo6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Fo7_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Fo7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Fp1_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Fp1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Fp2_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Fp2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-IFJ1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-IFJ1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-IFJ2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-IFJ2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-IFS1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-IFS1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-IFS2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-IFS2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-IFS3_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-IFS3_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-IFS4_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-IFS4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Ia1_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Ia1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Ia2_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Ia2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Ia3_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Ia3_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Id10_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Id10_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Id1_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Id1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Id2_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Id2_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Id3_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Id3_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Id4_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Id4_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Id5_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Id5_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Id6_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Id6_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Id7_PM-v8.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Id7_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Id8_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Id8_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Id9_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Id9_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Ig1_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Ig1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Ig2_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Ig2_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Ig3_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Ig3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-MFG1_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-MFG1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-MFG2_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-MFG2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-OP1_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-OP1_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-OP2_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-OP2_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-OP3_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-OP3_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-OP4_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-OP4_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-OP5_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-OP5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-OP6_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-OP6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-OP7_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-OP7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-OP8_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-OP8_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-OP9_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-OP9_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-PF_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-PF_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-PFcm_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-PFcm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-PFm_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-PFm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-PFop_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-PFop_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-PFt_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-PFt_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-PGa_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-PGa_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-PGp_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-PGp_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Ph1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Ph1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Ph2_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Ph2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Ph3_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-Ph3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-SFS1_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-SFS1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-SFS2_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-SFS2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-STS1_PM-v5.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-STS1_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-STS2_PM-v5.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-STS2_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-TE-1.0_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-TE-1.0_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-TE-1.1_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-TE-1.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-TE-1.2_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-TE-1.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-TE-2.1_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-TE-2.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-TE-2.2_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-TE-2.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-TE-3_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-TE-3_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-TI_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-TI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-TPJ_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-TPJ_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-TeI_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-TeI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hIP1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hIP1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hIP2_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hIP2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hIP3_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hIP3_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hIP4_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hIP4_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hIP5_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hIP5_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hIP6_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hIP6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hIP7_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hIP7_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hIP8_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hIP8_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hOc1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hOc1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hOc2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hOc2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hOc3d_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hOc3d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hOc3v_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hOc3v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hOc4d_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hOc4d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hOc4la_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hOc4la_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hOc4lp_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hOc4lp_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hOc4v_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hOc4v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hOc5_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hOc5_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hOc6_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hOc6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hPO1_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-hPO1_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-p24ab_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-p24ab_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-p24c_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-p24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-p32_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-p32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-s24_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-s24_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-s32_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Area-s32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_CA1_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_CA1_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_CA2_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_CA2_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_CA3_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_CA3_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_CGL_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_CGL_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_CGM_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_CGM_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_DG_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_DG_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Entorhinal-Cortex_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Entorhinal-Cortex_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Frontal-II_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Frontal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Frontal-I_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Frontal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Frontal-to-Occipital_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Frontal-to-Occipital_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Frontal-to-Temporal-II_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Frontal-to-Temporal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Frontal-to-Temporal-I_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Frontal-to-Temporal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_HATA_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_HATA_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_HC-Transsubiculum_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_HC-Transsubiculum_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Subiculum.PaS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Subiculum.PaS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Subiculum.PreS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Subiculum.PreS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Subiculum.ProS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Subiculum.ProS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Subiculum.Sub_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Subiculum.Sub_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Temporal-to-Parietal_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Temporal-to-Parietal_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Tuberculum_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.1-fsaverage/JBA_v3.0.1-fsaverage_Tuberculum_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-6d1_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-6d1_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-6d2_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-6d2_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-6d3_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-6d3_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-6ma_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-6ma_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-MFG1_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-MFG1_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-MFG2_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-MFG2_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-SFS1_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-SFS1_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-SFS2_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-SFS2_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-STS1_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-STS1_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-STS2_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-STS2_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-TE-1.0_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-TE-1.0_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-TE-1.1_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-TE-1.1_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-TE-1.2_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-TE-1.2_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-TE-3_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-TE-3_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hIP4_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hIP4_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hIP5_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hIP5_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hIP6_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hIP6_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hIP7_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hIP7_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hIP8_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hIP8_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hOc1_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hOc1_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hOc2_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hOc2_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hOc3v_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hOc3v_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hOc5_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hOc5_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hOc6_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hOc6_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hPO1_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Area-hPO1_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_CGL.lam1_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_CGL.lam1_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_CGL.lam2_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_CGL.lam2_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_CGL.lam3_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_CGL.lam3_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_CGL.lam4_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_CGL.lam4_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_CGL.lam5_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_CGL.lam5_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_CGL.lam6_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_CGL.lam6_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_CGM.CGMd_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_CGM.CGMd_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_CGM.CGMm_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_CGM.CGMm_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_CGM.CGMv_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_CGM.CGMv_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Entorhinal-Cortex_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-BigBrain/JBA_v3.0.2-BigBrain_Entorhinal-Cortex_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_AcbL_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_AcbL_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_AcbM_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_AcbM_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-1_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-1_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-25.25a_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-25.25a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-25.25p_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-25.25p_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-25_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-25_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-2_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-33_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-33_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-3a_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-3a_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-3b_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-3b_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-44_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-44_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-45_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-45_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-4a_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-4a_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-4p_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-4p_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-5Ci_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-5Ci_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-5L_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-5L_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-5M_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-5M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-6d1_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-6d1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-6d2_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-6d2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-6d3_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-6d3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-6ma_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-6ma_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-6mp_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-6mp_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-7A_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-7A_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-7M_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-7M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-7PC_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-7PC_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-7P_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-7P_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-8d1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-8d1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-8d2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-8d2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-8v1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-8v1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-8v2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-8v2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-CoS1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-CoS1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-FG1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-FG1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-FG2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-FG2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-FG3_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-FG3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-FG4_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-FG4_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Fo1_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Fo1_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Fo2_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Fo2_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Fo3_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Fo3_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Fo4_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Fo4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Fo5_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Fo5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Fo6_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Fo6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Fo7_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Fo7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Fp1_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Fp1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Fp2_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Fp2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-IFJ1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-IFJ1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-IFJ2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-IFJ2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-IFS1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-IFS1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-IFS2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-IFS2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-IFS3_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-IFS3_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-IFS4_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-IFS4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Ia1_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Ia1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Ia2_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Ia2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Ia3_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Ia3_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Id10_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Id10_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Id1_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Id1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Id2_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Id2_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Id3_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Id3_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Id4_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Id4_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Id5_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Id5_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Id6_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Id6_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Id7_PM-v8.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Id7_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Id8_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Id8_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Id9_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Id9_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Ig1_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Ig1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Ig2_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Ig2_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Ig3_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Ig3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-MFG1_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-MFG1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-MFG2_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-MFG2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-OP1_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-OP1_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-OP2_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-OP2_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-OP3_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-OP3_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-OP4_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-OP4_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-OP5_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-OP5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-OP6_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-OP6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-OP7_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-OP7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-OP8_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-OP8_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-OP9_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-OP9_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-PF_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-PF_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-PFcm_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-PFcm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-PFm_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-PFm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-PFop_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-PFop_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-PFt_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-PFt_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-PGa_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-PGa_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-PGp_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-PGp_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Ph1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Ph1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Ph2_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Ph2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Ph3_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-Ph3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-SFS1_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-SFS1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-SFS2_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-SFS2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-STS1_PM-v5.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-STS1_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-STS2_PM-v5.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-STS2_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-TE-1.0_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-TE-1.0_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-TE-1.1_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-TE-1.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-TE-1.2_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-TE-1.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-TE-2.1_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-TE-2.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-TE-2.2_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-TE-2.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-TE-3_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-TE-3_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-TI_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-TI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-TPJ_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-TPJ_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-TeI_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-TeI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hIP1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hIP1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hIP2_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hIP2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hIP3_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hIP3_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hIP4_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hIP4_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hIP5_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hIP5_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hIP6_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hIP6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hIP7_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hIP7_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hIP8_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hIP8_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hOc1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hOc1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hOc2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hOc2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hOc3d_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hOc3d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hOc3v_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hOc3v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hOc4d_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hOc4d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hOc4la_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hOc4la_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hOc4lp_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hOc4lp_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hOc4v_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hOc4v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hOc5_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hOc5_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hOc6_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hOc6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hPO1_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-hPO1_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-p24ab.p24a_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-p24ab.p24a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-p24ab.p24b_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-p24ab.p24b_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-p24ab_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-p24ab_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-p24c.pd24cd_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-p24c.pd24cd_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-p24c.pd24cv_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-p24c.pd24cv_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-p24c.pv24c_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-p24c.pv24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-p24c_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-p24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-p32_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-p32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-s24.s24a_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-s24.s24a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-s24.s24b_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-s24.s24b_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-s24_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-s24_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-s32_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Area-s32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_BST_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_BST_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_CA1_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_CA1_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_CA2_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_CA2_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_CA3_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_CA3_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_CGL_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_CGL_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_CGM_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_CGM_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_CM.AAA_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_CM.AAA_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_CM.Ce_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_CM.Ce_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_CM.Me_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_CM.Me_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_CM_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_CM_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Ch-123_PM-v4.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Ch-123_PM-v4.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Ch-4_PM-v4.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Ch-4_PM-v4.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_DG_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_DG_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Dorsal-Dentate-Nucleus_PM-v6.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Dorsal-Dentate-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Entorhinal-Cortex_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Entorhinal-Cortex_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Fastigial-Nucleus_PM-v6.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Fastigial-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Frontal-II_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Frontal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Frontal-I_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Frontal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Frontal-to-Occipital_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Frontal-to-Occipital_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Frontal-to-Temporal-II_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Frontal-to-Temporal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Frontal-to-Temporal-I_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Frontal-to-Temporal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_FuCd_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_FuCd_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_FuP_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_FuP_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_HATA_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_HATA_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_HC-Transsubiculum_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_HC-Transsubiculum_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_IF.ice_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_IF.ice_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_IF.iol_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_IF.iol_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_IF.ld_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_IF.ld_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_IF_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_IF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Interposed-Nucleus_PM-v6.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Interposed-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_LB.Bl_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_LB.Bl_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_LB.Bm_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_LB.Bm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_LB.La_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_LB.La_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_LB.Pl_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_LB.Pl_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_LB_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_LB_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_MF.icm_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_MF.icm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_MF.lm_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_MF.lm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_MF_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_MF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_SF.AHi_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_SF.AHi_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_SF.APir_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_SF.APir_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_SF.VCo_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_SF.VCo_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_SF_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_SF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_STN_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_STN_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Subiculum.PaS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Subiculum.PaS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Subiculum.PreS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Subiculum.PreS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Subiculum.ProS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Subiculum.ProS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Subiculum.Sub_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Subiculum.Sub_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Temporal-to-Parietal_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Temporal-to-Parietal_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Terminal-islands_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Terminal-islands_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Tuberculum_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Tuberculum_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_VP_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_VP_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_VTM_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_VTM_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Ventral-Dentate-Nucleus_PM-v6.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-Colin27/JBA_v3.0.2-Colin27_Ventral-Dentate-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_AcbL_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_AcbL_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_AcbM_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_AcbM_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-1_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-1_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-25.25a_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-25.25a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-25.25p_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-25.25p_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-25_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-25_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-2_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-33_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-33_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-3a_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-3a_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-3b_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-3b_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-44_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-44_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-45_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-45_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-4a_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-4a_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-4p_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-4p_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-5Ci_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-5Ci_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-5L_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-5L_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-5M_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-5M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-6d1_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-6d1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-6d2_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-6d2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-6d3_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-6d3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-6ma_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-6ma_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-6mp_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-6mp_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-7A_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-7A_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-7M_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-7M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-7PC_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-7PC_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-7P_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-7P_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-8d1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-8d1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-8d2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-8d2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-8v1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-8v1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-8v2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-8v2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-CoS1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-CoS1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-FG1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-FG1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-FG2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-FG2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-FG3_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-FG3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-FG4_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-FG4_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Fo1_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Fo1_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Fo2_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Fo2_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Fo3_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Fo3_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Fo4_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Fo4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Fo5_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Fo5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Fo6_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Fo6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Fo7_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Fo7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Fp1_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Fp1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Fp2_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Fp2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-IFJ1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-IFJ1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-IFJ2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-IFJ2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-IFS1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-IFS1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-IFS2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-IFS2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-IFS3_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-IFS3_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-IFS4_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-IFS4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Ia1_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Ia1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Ia2_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Ia2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Ia3_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Ia3_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Id10_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Id10_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Id1_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Id1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Id2_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Id2_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Id3_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Id3_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Id4_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Id4_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Id5_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Id5_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Id6_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Id6_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Id7_PM-v8.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Id7_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Id8_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Id8_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Id9_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Id9_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Ig1_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Ig1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Ig2_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Ig2_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Ig3_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Ig3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-MFG1_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-MFG1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-MFG2_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-MFG2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-OP1_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-OP1_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-OP2_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-OP2_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-OP3_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-OP3_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-OP4_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-OP4_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-OP5_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-OP5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-OP6_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-OP6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-OP7_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-OP7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-OP8_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-OP8_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-OP9_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-OP9_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-PF_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-PF_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-PFcm_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-PFcm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-PFm_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-PFm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-PFop_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-PFop_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-PFt_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-PFt_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-PGa_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-PGa_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-PGp_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-PGp_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Ph1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Ph1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Ph2_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Ph2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Ph3_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-Ph3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-SFS1_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-SFS1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-SFS2_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-SFS2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-STS1_PM-v5.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-STS1_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-STS2_PM-v5.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-STS2_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-TE-1.0_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-TE-1.0_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-TE-1.1_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-TE-1.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-TE-1.2_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-TE-1.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-TE-2.1_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-TE-2.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-TE-2.2_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-TE-2.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-TE-3_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-TE-3_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-TI_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-TI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-TPJ_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-TPJ_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-TeI_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-TeI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hIP1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hIP1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hIP2_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hIP2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hIP3_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hIP3_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hIP4_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hIP4_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hIP5_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hIP5_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hIP6_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hIP6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hIP7_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hIP7_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hIP8_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hIP8_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hOc1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hOc1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hOc2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hOc2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hOc3d_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hOc3d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hOc3v_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hOc3v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hOc4d_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hOc4d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hOc4la_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hOc4la_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hOc4lp_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hOc4lp_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hOc4v_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hOc4v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hOc5_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hOc5_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hOc6_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hOc6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hPO1_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-hPO1_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-p24ab.p24a_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-p24ab.p24a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-p24ab.p24b_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-p24ab.p24b_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-p24ab_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-p24ab_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-p24c.pd24cd_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-p24c.pd24cd_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-p24c.pd24cv_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-p24c.pd24cv_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-p24c.pv24c_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-p24c.pv24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-p24c_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-p24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-p32_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-p32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-s24.s24a_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-s24.s24a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-s24.s24b_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-s24.s24b_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-s24_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-s24_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-s32_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Area-s32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_BST_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_BST_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_CA1_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_CA1_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_CA2_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_CA2_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_CA3_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_CA3_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_CGL_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_CGL_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_CGM_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_CGM_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_CM.AAA_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_CM.AAA_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_CM.Ce_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_CM.Ce_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_CM.Me_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_CM.Me_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_CM_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_CM_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Ch-123_PM-v4.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Ch-123_PM-v4.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Ch-4_PM-v4.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Ch-4_PM-v4.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_DG_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_DG_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Dorsal-Dentate-Nucleus_PM-v6.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Dorsal-Dentate-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Entorhinal-Cortex_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Entorhinal-Cortex_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Fastigial-Nucleus_PM-v6.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Fastigial-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Frontal-II_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Frontal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Frontal-I_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Frontal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Frontal-to-Occipital_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Frontal-to-Occipital_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Frontal-to-Temporal-II_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Frontal-to-Temporal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Frontal-to-Temporal-I_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Frontal-to-Temporal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_FuCd_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_FuCd_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_FuP_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_FuP_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_HATA_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_HATA_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_HC-Transsubiculum_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_HC-Transsubiculum_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_IF.ice_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_IF.ice_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_IF.iol_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_IF.iol_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_IF.ld_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_IF.ld_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_IF_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_IF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Interposed-Nucleus_PM-v6.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Interposed-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_LB.Bl_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_LB.Bl_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_LB.Bm_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_LB.Bm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_LB.La_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_LB.La_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_LB.Pl_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_LB.Pl_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_LB_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_LB_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_MF.icm_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_MF.icm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_MF.lm_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_MF.lm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_MF_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_MF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_SF.AHi_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_SF.AHi_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_SF.APir_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_SF.APir_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_SF.VCo_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_SF.VCo_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_SF_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_SF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_STN_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_STN_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Subiculum.PaS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Subiculum.PaS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Subiculum.PreS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Subiculum.PreS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Subiculum.ProS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Subiculum.ProS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Subiculum.Sub_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Subiculum.Sub_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Temporal-to-Parietal_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Temporal-to-Parietal_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Terminal-islands_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Terminal-islands_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Tuberculum_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Tuberculum_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_VP_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_VP_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_VTM_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_VTM_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Ventral-Dentate-Nucleus_PM-v6.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-MNI152/JBA_v3.0.2-MNI152_Ventral-Dentate-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-1_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-1_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-25_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-25_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-2_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-33_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-33_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-3a_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-3a_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-3b_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-3b_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-44_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-44_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-45_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-45_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-4a_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-4a_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-4p_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-4p_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-5Ci_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-5Ci_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-5L_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-5L_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-5M_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-5M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-6d1_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-6d1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-6d2_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-6d2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-6d3_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-6d3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-6ma_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-6ma_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-6mp_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-6mp_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-7A_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-7A_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-7M_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-7M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-7PC_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-7PC_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-7P_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-7P_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-8d1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-8d1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-8d2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-8d2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-8v1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-8v1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-8v2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-8v2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-CoS1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-CoS1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-FG1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-FG1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-FG2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-FG2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-FG3_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-FG3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-FG4_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-FG4_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Fo1_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Fo1_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Fo2_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Fo2_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Fo3_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Fo3_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Fo4_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Fo4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Fo5_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Fo5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Fo6_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Fo6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Fo7_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Fo7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Fp1_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Fp1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Fp2_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Fp2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-IFJ1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-IFJ1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-IFJ2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-IFJ2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-IFS1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-IFS1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-IFS2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-IFS2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-IFS3_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-IFS3_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-IFS4_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-IFS4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Ia1_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Ia1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Ia2_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Ia2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Ia3_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Ia3_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Id10_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Id10_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Id1_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Id1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Id2_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Id2_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Id3_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Id3_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Id4_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Id4_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Id5_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Id5_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Id6_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Id6_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Id7_PM-v8.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Id7_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Id8_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Id8_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Id9_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Id9_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Ig1_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Ig1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Ig2_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Ig2_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Ig3_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Ig3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-MFG1_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-MFG1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-MFG2_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-MFG2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-OP1_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-OP1_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-OP2_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-OP2_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-OP3_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-OP3_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-OP4_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-OP4_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-OP5_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-OP5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-OP6_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-OP6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-OP7_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-OP7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-OP8_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-OP8_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-OP9_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-OP9_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-PF_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-PF_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-PFcm_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-PFcm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-PFm_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-PFm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-PFop_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-PFop_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-PFt_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-PFt_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-PGa_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-PGa_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-PGp_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-PGp_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Ph1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Ph1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Ph2_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Ph2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Ph3_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-Ph3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-SFS1_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-SFS1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-SFS2_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-SFS2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-STS1_PM-v5.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-STS1_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-STS2_PM-v5.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-STS2_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-TE-1.0_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-TE-1.0_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-TE-1.1_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-TE-1.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-TE-1.2_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-TE-1.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-TE-2.1_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-TE-2.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-TE-2.2_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-TE-2.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-TE-3_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-TE-3_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-TI_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-TI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-TPJ_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-TPJ_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-TeI_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-TeI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hIP1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hIP1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hIP2_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hIP2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hIP3_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hIP3_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hIP4_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hIP4_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hIP5_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hIP5_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hIP6_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hIP6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hIP7_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hIP7_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hIP8_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hIP8_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hOc1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hOc1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hOc2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hOc2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hOc3d_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hOc3d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hOc3v_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hOc3v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hOc4d_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hOc4d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hOc4la_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hOc4la_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hOc4lp_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hOc4lp_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hOc4v_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hOc4v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hOc5_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hOc5_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hOc6_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hOc6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hPO1_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-hPO1_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-p24ab_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-p24ab_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-p24c_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-p24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-p32_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-p32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-s24_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-s24_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-s32_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Area-s32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_CA1_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_CA1_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_CA2_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_CA2_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_CA3_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_CA3_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_CGL_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_CGL_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_CGM_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_CGM_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_DG_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_DG_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Entorhinal-Cortex_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Entorhinal-Cortex_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Frontal-II_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Frontal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Frontal-I_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Frontal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Frontal-to-Occipital_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Frontal-to-Occipital_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Frontal-to-Temporal-II_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Frontal-to-Temporal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Frontal-to-Temporal-I_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Frontal-to-Temporal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_HATA_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_HATA_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_HC-Transsubiculum_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_HC-Transsubiculum_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Subiculum.PaS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Subiculum.PaS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Subiculum.PreS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Subiculum.PreS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Subiculum.ProS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Subiculum.ProS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Subiculum.Sub_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Subiculum.Sub_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Temporal-to-Parietal_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Temporal-to-Parietal_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Tuberculum_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.2-fsaverage/JBA_v3.0.2-fsaverage_Tuberculum_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-6d1_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-6d1_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-6d2_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-6d2_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-6d3_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-6d3_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-6ma_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-6ma_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-MFG1_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-MFG1_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-MFG2_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-MFG2_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-SFS1_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-SFS1_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-SFS2_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-SFS2_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-STS1_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-STS1_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-STS2_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-STS2_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-TE-1.0_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-TE-1.0_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-TE-1.1_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-TE-1.1_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-TE-1.2_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-TE-1.2_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-TE-3_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-TE-3_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hIP4_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hIP4_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hIP5_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hIP5_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hIP6_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hIP6_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hIP7_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hIP7_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hIP8_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hIP8_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hOc1_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hOc1_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hOc2_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hOc2_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hOc3v_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hOc3v_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hOc5_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hOc5_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hOc6_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hOc6_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hPO1_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Area-hPO1_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_CGL.lam1_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_CGL.lam1_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_CGL.lam2_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_CGL.lam2_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_CGL.lam3_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_CGL.lam3_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_CGL.lam4_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_CGL.lam4_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_CGL.lam5_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_CGL.lam5_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_CGL.lam6_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_CGL.lam6_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_CGM.CGMd_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_CGM.CGMd_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_CGM.CGMm_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_CGM.CGMm_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_CGM.CGMv_deep.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_CGM.CGMv_deep.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Entorhinal-Cortex_int.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-BigBrain/JBA_v3.0.3-BigBrain_Entorhinal-Cortex_int.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_AcbL_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_AcbL_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_AcbM_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_AcbM_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-1_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-1_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-25.25a_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-25.25a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-25.25p_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-25.25p_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-25_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-25_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-2_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-33_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-33_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-3a_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-3a_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-3b_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-3b_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-44_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-44_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-45_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-45_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-4a_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-4a_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-4p_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-4p_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-5Ci_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-5Ci_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-5L_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-5L_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-5M_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-5M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-6d1_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-6d1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-6d2_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-6d2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-6d3_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-6d3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-6ma_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-6ma_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-6mp_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-6mp_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-7A_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-7A_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-7M_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-7M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-7PC_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-7PC_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-7P_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-7P_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-8d1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-8d1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-8d2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-8d2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-8v1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-8v1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-8v2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-8v2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-CoS1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-CoS1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-FG1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-FG1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-FG2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-FG2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-FG3_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-FG3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-FG4_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-FG4_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Fo1_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Fo1_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Fo2_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Fo2_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Fo3_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Fo3_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Fo4_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Fo4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Fo5_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Fo5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Fo6_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Fo6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Fo7_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Fo7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Fp1_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Fp1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Fp2_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Fp2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-IFJ1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-IFJ1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-IFJ2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-IFJ2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-IFS1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-IFS1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-IFS2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-IFS2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-IFS3_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-IFS3_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-IFS4_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-IFS4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Ia1_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Ia1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Ia2_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Ia2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Ia3_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Ia3_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Id10_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Id10_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Id1_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Id1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Id2_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Id2_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Id3_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Id3_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Id4_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Id4_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Id5_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Id5_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Id6_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Id6_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Id7_PM-v8.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Id7_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Id8_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Id8_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Id9_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Id9_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Ig1_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Ig1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Ig2_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Ig2_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Ig3_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Ig3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-MFG1_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-MFG1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-MFG2_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-MFG2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-OP1_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-OP1_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-OP2_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-OP2_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-OP3_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-OP3_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-OP4_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-OP4_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-OP5_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-OP5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-OP6_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-OP6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-OP7_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-OP7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-OP8_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-OP8_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-OP9_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-OP9_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-PF_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-PF_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-PFcm_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-PFcm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-PFm_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-PFm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-PFop_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-PFop_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-PFt_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-PFt_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-PGa_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-PGa_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-PGp_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-PGp_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Ph1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Ph1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Ph2_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Ph2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Ph3_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-Ph3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-SFS1_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-SFS1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-SFS2_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-SFS2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-STS1_PM-v5.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-STS1_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-STS2_PM-v5.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-STS2_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-TE-1.0_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-TE-1.0_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-TE-1.1_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-TE-1.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-TE-1.2_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-TE-1.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-TE-2.1_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-TE-2.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-TE-2.2_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-TE-2.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-TE-3_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-TE-3_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-TI_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-TI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-TPJ_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-TPJ_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-TeI_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-TeI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hIP1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hIP1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hIP2_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hIP2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hIP3_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hIP3_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hIP4_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hIP4_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hIP5_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hIP5_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hIP6_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hIP6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hIP7_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hIP7_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hIP8_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hIP8_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hOc1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hOc1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hOc2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hOc2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hOc3d_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hOc3d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hOc3v_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hOc3v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hOc4d_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hOc4d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hOc4la_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hOc4la_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hOc4lp_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hOc4lp_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hOc4v_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hOc4v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hOc5_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hOc5_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hOc6_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hOc6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hPO1_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-hPO1_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-p24ab.p24a_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-p24ab.p24a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-p24ab.p24b_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-p24ab.p24b_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-p24ab_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-p24ab_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-p24c.pd24cd_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-p24c.pd24cd_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-p24c.pd24cv_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-p24c.pd24cv_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-p24c.pv24c_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-p24c.pv24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-p24c_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-p24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-p32_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-p32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-s24.s24a_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-s24.s24a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-s24.s24b_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-s24.s24b_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-s24_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-s24_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-s32_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Area-s32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_BST_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_BST_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_CA1_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_CA1_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_CA2_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_CA2_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_CA3_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_CA3_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_CGL_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_CGL_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_CGM_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_CGM_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_CM.AAA_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_CM.AAA_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_CM.Ce_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_CM.Ce_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_CM.Me_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_CM.Me_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_CM_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_CM_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Ch-123_PM-v4.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Ch-123_PM-v4.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Ch-4_PM-v4.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Ch-4_PM-v4.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_DG_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_DG_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Dorsal-Dentate-Nucleus_PM-v6.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Dorsal-Dentate-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Entorhinal-Cortex_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Entorhinal-Cortex_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Fastigial-Nucleus_PM-v6.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Fastigial-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Frontal-II_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Frontal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Frontal-I_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Frontal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Frontal-to-Occipital_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Frontal-to-Occipital_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Frontal-to-Temporal-II_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Frontal-to-Temporal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Frontal-to-Temporal-I_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Frontal-to-Temporal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_FuCd_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_FuCd_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_FuP_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_FuP_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_HATA_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_HATA_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_HC-Transsubiculum_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_HC-Transsubiculum_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_IF.ice_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_IF.ice_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_IF.iol_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_IF.iol_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_IF.ld_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_IF.ld_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_IF_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_IF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Interposed-Nucleus_PM-v6.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Interposed-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_LB.Bl_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_LB.Bl_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_LB.Bm_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_LB.Bm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_LB.La_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_LB.La_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_LB.Pl_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_LB.Pl_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_LB_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_LB_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_MF.icm_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_MF.icm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_MF.lm_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_MF.lm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_MF_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_MF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_SF.AHi_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_SF.AHi_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_SF.APir_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_SF.APir_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_SF.VCo_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_SF.VCo_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_SF_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_SF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_STN_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_STN_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Subiculum.PaS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Subiculum.PaS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Subiculum.PreS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Subiculum.PreS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Subiculum.ProS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Subiculum.ProS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Subiculum.Sub_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Subiculum.Sub_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Temporal-to-Parietal_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Temporal-to-Parietal_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Terminal-islands_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Terminal-islands_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Tuberculum_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Tuberculum_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_VP_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_VP_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_VTM_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_VTM_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Ventral-Dentate-Nucleus_PM-v6.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-Colin27/JBA_v3.0.3-Colin27_Ventral-Dentate-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_AcbL_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_AcbL_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_AcbM_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_AcbM_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-1_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-1_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-25.25a_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-25.25a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-25.25p_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-25.25p_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-25_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-25_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-2_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-33_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-33_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-3a_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-3a_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-3b_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-3b_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-44_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-44_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-45_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-45_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-4a_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-4a_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-4p_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-4p_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-5Ci_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-5Ci_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-5L_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-5L_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-5M_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-5M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-6d1_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-6d1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-6d2_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-6d2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-6d3_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-6d3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-6ma_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-6ma_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-6mp_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-6mp_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-7A_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-7A_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-7M_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-7M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-7PC_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-7PC_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-7P_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-7P_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-8d1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-8d1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-8d2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-8d2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-8v1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-8v1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-8v2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-8v2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-CoS1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-CoS1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-FG1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-FG1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-FG2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-FG2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-FG3_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-FG3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-FG4_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-FG4_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Fo1_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Fo1_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Fo2_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Fo2_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Fo3_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Fo3_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Fo4_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Fo4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Fo5_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Fo5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Fo6_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Fo6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Fo7_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Fo7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Fp1_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Fp1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Fp2_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Fp2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-IFJ1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-IFJ1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-IFJ2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-IFJ2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-IFS1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-IFS1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-IFS2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-IFS2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-IFS3_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-IFS3_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-IFS4_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-IFS4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Ia1_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Ia1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Ia2_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Ia2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Ia3_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Ia3_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Id10_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Id10_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Id1_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Id1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Id2_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Id2_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Id3_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Id3_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Id4_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Id4_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Id5_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Id5_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Id6_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Id6_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Id7_PM-v8.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Id7_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Id8_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Id8_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Id9_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Id9_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Ig1_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Ig1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Ig2_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Ig2_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Ig3_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Ig3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-MFG1_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-MFG1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-MFG2_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-MFG2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-OP1_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-OP1_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-OP2_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-OP2_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-OP3_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-OP3_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-OP4_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-OP4_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-OP5_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-OP5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-OP6_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-OP6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-OP7_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-OP7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-OP8_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-OP8_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-OP9_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-OP9_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-PF_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-PF_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-PFcm_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-PFcm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-PFm_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-PFm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-PFop_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-PFop_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-PFt_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-PFt_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-PGa_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-PGa_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-PGp_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-PGp_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Ph1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Ph1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Ph2_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Ph2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Ph3_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-Ph3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-SFS1_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-SFS1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-SFS2_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-SFS2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-STS1_PM-v5.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-STS1_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-STS2_PM-v5.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-STS2_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-TE-1.0_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-TE-1.0_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-TE-1.1_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-TE-1.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-TE-1.2_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-TE-1.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-TE-2.1_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-TE-2.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-TE-2.2_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-TE-2.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-TE-3_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-TE-3_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-TI_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-TI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-TPJ_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-TPJ_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-TeI_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-TeI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hIP1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hIP1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hIP2_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hIP2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hIP3_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hIP3_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hIP4_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hIP4_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hIP5_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hIP5_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hIP6_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hIP6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hIP7_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hIP7_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hIP8_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hIP8_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hOc1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hOc1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hOc2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hOc2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hOc3d_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hOc3d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hOc3v_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hOc3v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hOc4d_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hOc4d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hOc4la_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hOc4la_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hOc4lp_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hOc4lp_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hOc4v_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hOc4v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hOc5_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hOc5_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hOc6_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hOc6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hPO1_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-hPO1_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-p24ab.p24a_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-p24ab.p24a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-p24ab.p24b_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-p24ab.p24b_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-p24ab_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-p24ab_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-p24c.pd24cd_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-p24c.pd24cd_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-p24c.pd24cv_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-p24c.pd24cv_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-p24c.pv24c_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-p24c.pv24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-p24c_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-p24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-p32_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-p32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-s24.s24a_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-s24.s24a_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-s24.s24b_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-s24.s24b_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-s24_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-s24_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-s32_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Area-s32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_BST_PM-v6.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_BST_PM-v6.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_CA1_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_CA1_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_CA2_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_CA2_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_CA3_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_CA3_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_CGL_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_CGL_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_CGM_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_CGM_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_CM.AAA_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_CM.AAA_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_CM.Ce_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_CM.Ce_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_CM.Me_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_CM.Me_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_CM_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_CM_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Ch-123_PM-v4.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Ch-123_PM-v4.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Ch-4_PM-v4.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Ch-4_PM-v4.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_DG_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_DG_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Dorsal-Dentate-Nucleus_PM-v6.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Dorsal-Dentate-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Entorhinal-Cortex_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Entorhinal-Cortex_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Fastigial-Nucleus_PM-v6.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Fastigial-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Frontal-II_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Frontal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Frontal-I_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Frontal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Frontal-to-Occipital_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Frontal-to-Occipital_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Frontal-to-Temporal-II_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Frontal-to-Temporal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Frontal-to-Temporal-I_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Frontal-to-Temporal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_FuCd_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_FuCd_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_FuP_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_FuP_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_HATA_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_HATA_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_HC-Transsubiculum_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_HC-Transsubiculum_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_IF.ice_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_IF.ice_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_IF.iol_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_IF.iol_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_IF.ld_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_IF.ld_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_IF_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_IF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Interposed-Nucleus_PM-v6.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Interposed-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_LB.Bl_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_LB.Bl_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_LB.Bm_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_LB.Bm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_LB.La_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_LB.La_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_LB.Pl_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_LB.Pl_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_LB_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_LB_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_MF.icm_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_MF.icm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_MF.lm_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_MF.lm_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_MF_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_MF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_SF.AHi_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_SF.AHi_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_SF.APir_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_SF.APir_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_SF.VCo_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_SF.VCo_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_SF_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_SF_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_STN_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_STN_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Subiculum.PaS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Subiculum.PaS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Subiculum.PreS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Subiculum.PreS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Subiculum.ProS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Subiculum.ProS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Subiculum.Sub_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Subiculum.Sub_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Temporal-to-Parietal_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Temporal-to-Parietal_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Terminal-islands_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Terminal-islands_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Tuberculum_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Tuberculum_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_VP_PM-v5.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_VP_PM-v5.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_VTM_PM-v8.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_VTM_PM-v8.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Ventral-Dentate-Nucleus_PM-v6.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-MNI152/JBA_v3.0.3-MNI152_Ventral-Dentate-Nucleus_PM-v6.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -32,7 +31,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-1_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-1_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-25_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-25_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-2_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-33_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-33_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-3a_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-3a_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-3b_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-3b_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-44_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-44_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-45_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-45_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-4a_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-4a_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-4p_PM-v13.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-4p_PM-v13.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-5Ci_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-5Ci_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-5L_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-5L_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-5M_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-5M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-6d1_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-6d1_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-6d2_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-6d2_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-6d3_PM-v7.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-6d3_PM-v7.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-6ma_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-6ma_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-6mp_PM-v12.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-6mp_PM-v12.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-7A_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-7A_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-7M_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-7M_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-7PC_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-7PC_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-7P_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-7P_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-8d1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-8d1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-8d2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-8d2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-8v1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-8v1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-8v2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-8v2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-CoS1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-CoS1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-FG1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-FG1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-FG2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-FG2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-FG3_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-FG3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-FG4_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-FG4_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Fo1_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Fo1_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Fo2_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Fo2_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Fo3_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Fo3_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Fo4_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Fo4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Fo5_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Fo5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Fo6_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Fo6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Fo7_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Fo7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Fp1_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Fp1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Fp2_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Fp2_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-IFJ1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-IFJ1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-IFJ2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-IFJ2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-IFS1_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-IFS1_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-IFS2_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-IFS2_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-IFS3_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-IFS3_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-IFS4_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-IFS4_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Ia1_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Ia1_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Ia2_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Ia2_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Ia3_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Ia3_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Id10_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Id10_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Id1_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Id1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Id2_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Id2_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Id3_PM-v9.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Id3_PM-v9.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Id4_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Id4_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Id5_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Id5_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Id6_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Id6_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Id7_PM-v8.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Id7_PM-v8.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Id8_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Id8_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Id9_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Id9_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Ig1_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Ig1_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Ig2_PM-v14.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Ig2_PM-v14.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Ig3_PM-v5.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Ig3_PM-v5.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-MFG1_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-MFG1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-MFG2_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-MFG2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-OP1_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-OP1_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-OP2_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-OP2_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-OP3_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-OP3_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-OP4_PM-v12.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-OP4_PM-v12.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-OP5_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-OP5_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-OP6_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-OP6_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-OP7_PM-v3.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-OP7_PM-v3.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-OP8_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-OP8_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-OP9_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-OP9_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-PF_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-PF_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-PFcm_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-PFcm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-PFm_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-PFm_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-PFop_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-PFop_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-PFt_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-PFt_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-PGa_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-PGa_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-PGp_PM-v11.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-PGp_PM-v11.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Ph1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Ph1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Ph2_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Ph2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Ph3_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-Ph3_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-SFS1_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-SFS1_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-SFS2_PM-v9.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-SFS2_PM-v9.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-STS1_PM-v5.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-STS1_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-STS2_PM-v5.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-STS2_PM-v5.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-TE-1.0_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-TE-1.0_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-TE-1.1_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-TE-1.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-TE-1.2_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-TE-1.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-TE-2.1_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-TE-2.1_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-TE-2.2_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-TE-2.2_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-TE-3_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-TE-3_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-TI_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-TI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-TPJ_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-TPJ_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-TeI_PM-v6.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-TeI_PM-v6.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hIP1_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hIP1_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hIP2_PM-v7.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hIP2_PM-v7.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hIP3_PM-v9.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hIP3_PM-v9.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hIP4_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hIP4_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hIP5_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hIP5_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hIP6_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hIP6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hIP7_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hIP7_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hIP8_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hIP8_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hOc1_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hOc1_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hOc2_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hOc2_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hOc3d_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hOc3d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hOc3v_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hOc3v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hOc4d_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hOc4d_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hOc4la_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hOc4la_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hOc4lp_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hOc4lp_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hOc4v_PM-v5.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hOc4v_PM-v5.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hOc5_PM-v4.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hOc5_PM-v4.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hOc6_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hOc6_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hPO1_PM-v7.3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-hPO1_PM-v7.3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-p24ab_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-p24ab_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-p24c_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-p24c_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-p32_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-p32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-s24_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-s24_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-s32_PM-v20.1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Area-s32_PM-v20.1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_CA1_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_CA1_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_CA2_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_CA2_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_CA3_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_CA3_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_CGL_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_CGL_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_CGM_PM-v10.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_CGM_PM-v10.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_DG_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_DG_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Entorhinal-Cortex_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Entorhinal-Cortex_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Frontal-II_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Frontal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Frontal-I_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Frontal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Frontal-to-Occipital_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Frontal-to-Occipital_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Frontal-to-Temporal-II_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Frontal-to-Temporal-II_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Frontal-to-Temporal-I_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Frontal-to-Temporal-I_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_HATA_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_HATA_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_HC-Transsubiculum_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_HC-Transsubiculum_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Subiculum.PaS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Subiculum.PaS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Subiculum.PreS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Subiculum.PreS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Subiculum.ProS_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Subiculum.ProS_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Subiculum.Sub_PM-v13.2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Subiculum.Sub_PM-v13.2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Temporal-to-Parietal_PM-v11.4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Temporal-to-Parietal_PM-v11.4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Tuberculum_PM-v4.0.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/JBA_v3.0.3-fsaverage/JBA_v3.0.3-fsaverage_Tuberculum_PM-v4.0.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -30,7 +29,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_agranularInsularCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_agranularInsularCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_amygdalopiriformTransitionArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_amygdalopiriformTransitionArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_anteriorIntraparietalAreaOfCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_anteriorIntraparietalAreaOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area10OfCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area10OfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area11OfCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area11OfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area13OfCortexLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area13OfCortexLateralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area13OfCortexMedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area13OfCortexMedialPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area13aOfCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area13aOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area13bOfCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area13bOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area14OfCortexCaudalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area14OfCortexCaudalPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area14OfCortexRostralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area14OfCortexRostralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area19OfCortexDorsointermediatePart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area19OfCortexDorsointermediatePart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area19OfCortexMedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area19OfCortexMedialPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area23OfCortexVentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area23OfCortexVentralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area23aOfCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area23aOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area23bOfCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area23bOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area23cOfCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area23cOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area24aOfCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area24aOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area24bOfCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area24bOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area24cOfCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area24cOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area24dOfCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area24dOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area25OfCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area25OfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area29a-cOfCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area29a-cOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area29dOfCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area29dOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area30OfCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area30OfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area31OfCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area31OfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area32OfCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area32OfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area32OfCortexVentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area32OfCortexVentralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area35OfCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area35OfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area36OfCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area36OfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area3aOfCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area3aOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area3bOfCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area3bOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area45OfCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area45OfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area46OfCortexDorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area46OfCortexDorsalPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area46OfCortexVentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area46OfCortexVentralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area47OfCortexLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area47OfCortexLateralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area47OfCortexMedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area47OfCortexMedialPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area47OfCortexOrbitalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area47OfCortexOrbitalPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area4OfCortexPartC.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area4OfCortexPartC.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area4OfCortexPartsAAndB.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area4OfCortexPartsAAndB.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area6OfCortexDorsocaudalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area6OfCortexDorsocaudalPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area6OfCortexDorsorostralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area6OfCortexDorsorostralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area6OfCortexMedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area6OfCortexMedialPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area6OfCortexVentralPartA.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area6OfCortexVentralPartA.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area6OfCortexVentralPartB.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area6OfCortexVentralPartB.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area8OfCortexCaudalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area8OfCortexCaudalPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area8aOfCortexDorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area8aOfCortexDorsalPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area8aOfCortexVentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area8aOfCortexVentralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area8bOfCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area8bOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area9OfCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area9OfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_areas1And2OfCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_areas1And2OfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexAnterolateralArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexAnterolateralArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexCaudalParabeltArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexCaudalParabeltArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexCaudolateralArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexCaudolateralArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexCaudomedialArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexCaudomedialArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexMiddleLateralArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexMiddleLateralArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexPrimaryArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexPrimaryArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexRostralArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexRostralArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexRostralParabelt.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexRostralParabelt.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexRostromedialArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexRostromedialArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexRostrotemporal.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexRostrotemporal.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexRostrotemporalLateralArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexRostrotemporalLateralArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexRostrotemporalMedialArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexRostrotemporalMedialArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_dysgranularInsularCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_dysgranularInsularCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_entorhinalCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_entorhinalCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_fundusOfSuperiorTemporalSulcusAreaOfCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_fundusOfSuperiorTemporalSulcusAreaOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_granularInsularCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_granularInsularCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_gustatoryCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_gustatoryCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_insularProisocortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_insularProisocortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_lateralIntraparietalAreaOfCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_lateralIntraparietalAreaOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_medialIntraparietalAreaOfCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_medialIntraparietalAreaOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_medialSuperiorTemporalAreaOfCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_medialSuperiorTemporalAreaOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_occipito-parietalTransitionalAreaOfCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_occipito-parietalTransitionalAreaOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_orbitalPeriallocortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_orbitalPeriallocortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_orbitalProisocortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_orbitalProisocortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parainsularCortexLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parainsularCortexLateralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parainsularCortexMedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parainsularCortexMedialPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreaPE.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreaPE.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreaPECaudalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreaPECaudalPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreaPF.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreaPF.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreaPFG.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreaPFG.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreaPG.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreaPG.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreaPGMedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreaPGMedialPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreasPGaAndIPa.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreasPGaAndIPa.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_piriformCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_piriformCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_primaryVisualCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_primaryVisualCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_proisocorticalMotorRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_proisocorticalMotorRegion.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_prostriateArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_prostriateArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_retroinsularArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_retroinsularArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_secondarySomatosensoryCortexExternalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_secondarySomatosensoryCortexExternalPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_secondarySomatosensoryCortexInternalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_secondarySomatosensoryCortexInternalPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_secondarySomatosensoryCortexParietalRostralArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_secondarySomatosensoryCortexParietalRostralArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_secondarySomatosensoryCortexParietalVentralArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_secondarySomatosensoryCortexParietalVentralArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_superiorTemporalRostralArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_superiorTemporalRostralArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTE1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTE1.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTE2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTE2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTE3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTE3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTEOccipitalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTEOccipitalPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTF.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTF.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTFOccipitalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTFOccipitalPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTH.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTH.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTL.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTL.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTLOccipitalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTLOccipitalPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalProisocortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalProisocortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporo-parieto-occipitalAssociationArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporo-parieto-occipitalAssociationArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporoparietalTransitionalArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporoparietalTransitionalArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporopolarProisocortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporopolarProisocortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_ventralIntraparietalAreaOfCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_ventralIntraparietalAreaOfCortex.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea2.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea3.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea3A.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea3A.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea4.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea4.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea4TransitionalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea4TransitionalPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -44,7 +43,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea5.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea5.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea6.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea6.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea6A.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea6A.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
@@ -42,7 +41,6 @@
     },
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_alveusOfTheHippocampus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_alveusOfTheHippocampus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_anteriorCommissureAnteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_anteriorCommissureAnteriorPart.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_anteriorCommissureIntrabulbarPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_anteriorCommissureIntrabulbarPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_anteriorCommissurePosteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_anteriorCommissurePosteriorPart.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_ascendingFibersOfTheFacialNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_ascendingFibersOfTheFacialNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_basalForebrainRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_basalForebrainRegion.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_bedNucleusOfTheStriaTerminalis.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_bedNucleusOfTheStriaTerminalis.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_brachiumOfTheSuperiorColliculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_brachiumOfTheSuperiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_brainstem.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_brainstem.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_caudalEntorhinalField.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_caudalEntorhinalField.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_centralCanal.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_centralCanal.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_cingulateCortexArea2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_cingulateCortexArea2.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_commissuralStriaTerminalis.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_commissuralStriaTerminalis.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_commissureOfTheInferiorColliculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_commissureOfTheInferiorColliculus.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_commissureOfTheSuperiorColliculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_commissureOfTheSuperiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_corpusCallosumAndAssociatedSubcorticalWhiteMatter.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_corpusCallosumAndAssociatedSubcorticalWhiteMatter.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_deeperCerebellum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_deeperCerebellum.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_deeperLayersOfTheSuperiorColliculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_deeperLayersOfTheSuperiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_descendingCorticofugalPathways.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_descendingCorticofugalPathways.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_dorsalintermediateEntorhinalArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_dorsalintermediateEntorhinalArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_dorsallateralEntorhinalArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_dorsallateralEntorhinalArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_entopeduncularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_entopeduncularNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_facialNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_facialNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_fasciculusRetroflexus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_fasciculusRetroflexus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_fimbriaOfTheHippocampus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_fimbriaOfTheHippocampus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_fornix.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_fornix.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_frontalAssociationCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_frontalAssociationCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_genuOfTheFacialNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_genuOfTheFacialNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_globusPallidus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_globusPallidus.jsonld
@@ -15,7 +15,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_glomerularLayerOfTheAccessoryOlfactoryBulb.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_glomerularLayerOfTheAccessoryOlfactoryBulb.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_glomerularLayerOfTheOlfactoryBulb.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_glomerularLayerOfTheOlfactoryBulb.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_habenularCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_habenularCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_hippocampalFormation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_hippocampalFormation.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_hypothalamicRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_hypothalamicRegion.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_inferiorCerebellarPeduncle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_inferiorCerebellarPeduncle.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_inferiorColliculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_inferiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_inferiorOlive.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_inferiorOlive.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_innerEar.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_innerEar.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_interpeduncularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_interpeduncularNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_mammillothalamicTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_mammillothalamicTract.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_medialEntorhinalField.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_medialEntorhinalField.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_medialLemniscus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_medialLemniscus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_medialLemniscusDecussation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_medialLemniscusDecussation.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_middleCerebellarPeduncle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_middleCerebellarPeduncle.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_molecularCellLayerOfTheCerebellum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_molecularCellLayerOfTheCerebellum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_neocortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_neocortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_nucleusOfTheStriaMedullaris.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_nucleusOfTheStriaMedullaris.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_olfactoryBulb.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_olfactoryBulb.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_opticNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_opticNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_opticTractAndOpticChiasm.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_opticTractAndOpticChiasm.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_periaqueductalGray.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_periaqueductalGray.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_perirhinalCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_perirhinalCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_periventricularGray.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_periventricularGray.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_pinealGland.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_pinealGland.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_pontineNuclei.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_pontineNuclei.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_posteriorCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_posteriorCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_postrhinalCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_postrhinalCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_pretectalRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_pretectalRegion.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_pyramidalDecussation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_pyramidalDecussation.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_septalRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_septalRegion.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_spinalCord.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_spinalCord.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_spinalTrigeminalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_spinalTrigeminalNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_spinalTrigeminalTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_spinalTrigeminalTract.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_striaMedullarisOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_striaMedullarisOfTheThalamus.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_striaTerminalis.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_striaTerminalis.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_striatum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_striatum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_subiculum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_subiculum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_substantiaNigra.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_substantiaNigra.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_subthalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_subthalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_superficialGrayLayerOfTheSuperiorColliculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_superficialGrayLayerOfTheSuperiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_supraopticDecussation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_supraopticDecussation.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_thalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_thalamus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_transverseFibersOfThePons.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_transverseFibersOfThePons.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_ventralHippocampalCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_ventralHippocampalCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_ventralintermediateEntorhinalArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_ventralintermediateEntorhinalArea.jsonld
@@ -11,7 +11,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_ventricularSystem.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v1.01/WHSSDatlas_v1.01_ventricularSystem.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_alveusOfTheHippocampus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_alveusOfTheHippocampus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_anteriorCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_anteriorCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_anteriorCommissureAnteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_anteriorCommissureAnteriorPart.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_anteriorCommissurePosteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_anteriorCommissurePosteriorPart.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_ascendingFibersOfTheFacialNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_ascendingFibersOfTheFacialNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_basalForebrainRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_basalForebrainRegion.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_bedNucleusOfTheStriaTerminalis.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_bedNucleusOfTheStriaTerminalis.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_brachiumOfTheSuperiorColliculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_brachiumOfTheSuperiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_brainstem.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_brainstem.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_centralCanal.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_centralCanal.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_cingulateCortexArea2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_cingulateCortexArea2.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_commissuralStriaTerminalis.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_commissuralStriaTerminalis.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_commissureOfTheInferiorColliculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_commissureOfTheInferiorColliculus.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_commissureOfTheSuperiorColliculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_commissureOfTheSuperiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_cornuAmmonis1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_cornuAmmonis1.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_cornuAmmonis2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_cornuAmmonis2.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_cornuAmmonis3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_cornuAmmonis3.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_corpusCallosumAndAssociatedSubcorticalWhiteMatter.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_corpusCallosumAndAssociatedSubcorticalWhiteMatter.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_deeperLayersOfTheSuperiorColliculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_deeperLayersOfTheSuperiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_dentateGyrus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_dentateGyrus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_descendingCorticofugalPathways.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_descendingCorticofugalPathways.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_entopeduncularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_entopeduncularNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_entorhinalCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_entorhinalCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_facialNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_facialNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_fasciculusRetroflexus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_fasciculusRetroflexus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_fasciolaCinereum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_fasciolaCinereum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_fimbriaOfTheHippocampus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_fimbriaOfTheHippocampus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_fornix.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_fornix.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_frontalAssociationCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_frontalAssociationCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_genuOfTheFacialNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_genuOfTheFacialNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_globusPallidus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_globusPallidus.jsonld
@@ -15,7 +15,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_glomerularLayerOfTheAccessoryOlfactoryBulb.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_glomerularLayerOfTheAccessoryOlfactoryBulb.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_glomerularLayerOfTheOlfactoryBulb.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_glomerularLayerOfTheOlfactoryBulb.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_granuleCellLevelOfTheCerebellum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_granuleCellLevelOfTheCerebellum.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_habenularCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_habenularCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_hypothalamicRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_hypothalamicRegion.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_inferiorCerebellarPeduncle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_inferiorCerebellarPeduncle.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_inferiorColliculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_inferiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_inferiorOlive.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_inferiorOlive.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_innerEar.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_innerEar.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_interpeduncularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_interpeduncularNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_lateralEntorhinalCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_lateralEntorhinalCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_mammillothalamicTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_mammillothalamicTract.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_medialLemniscus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_medialLemniscus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_medialLemniscusDecussation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_medialLemniscusDecussation.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_middleCerebellarPeduncle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_middleCerebellarPeduncle.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_molecularLayerOfTheCerebellum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_molecularLayerOfTheCerebellum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_neocortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_neocortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_nucleusOfTheStriaMedullaris.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_nucleusOfTheStriaMedullaris.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_olfactoryBulb.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_olfactoryBulb.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_opticNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_opticNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_opticTractAndOpticChiasm.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_opticTractAndOpticChiasm.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_parasubiculum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_parasubiculum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_periaqueductalGray.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_periaqueductalGray.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_perirhinalArea35.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_perirhinalArea35.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_perirhinalArea36.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_perirhinalArea36.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_periventricularGray.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_periventricularGray.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_pinealGland.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_pinealGland.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_pontineNuclei.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_pontineNuclei.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_posteriorCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_posteriorCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_postrhinalCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_postrhinalCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_presubiculum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_presubiculum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_pretectalRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_pretectalRegion.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_pyramidalDecussation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_pyramidalDecussation.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_septalRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_septalRegion.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_spinalCord.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_spinalCord.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_spinalTrigeminalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_spinalTrigeminalNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_spinalTrigeminalTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_spinalTrigeminalTract.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_striaMedullarisOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_striaMedullarisOfTheThalamus.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_striaTerminalis.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_striaTerminalis.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_striatum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_striatum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_subiculum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_subiculum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_substantiaNigra.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_substantiaNigra.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_subthalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_subthalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_superficialGrayLayerOfTheSuperiorColliculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_superficialGrayLayerOfTheSuperiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_supraopticDecussation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_supraopticDecussation.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_thalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_thalamus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_transverseFibersOfThePons.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_transverseFibersOfThePons.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_ventralHippocampalCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_ventralHippocampalCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_ventricularSystem.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v2/WHSSDatlas_v2_ventricularSystem.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_4thVentricle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_4thVentricle.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_acousticStriae.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_acousticStriae.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_alveusOfTheHippocampus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_alveusOfTheHippocampus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_anteriorCommissureAnteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_anteriorCommissureAnteriorPart.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_anteriorCommissureIntrabulbarPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_anteriorCommissureIntrabulbarPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_anteriorCommissurePosteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_anteriorCommissurePosteriorPart.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_ascendingFibersOfTheFacialNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_ascendingFibersOfTheFacialNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_auditoryRadiation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_auditoryRadiation.jsonld
@@ -15,7 +15,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_basalForebrainRegionUnspecified.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_basalForebrainRegionUnspecified.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_bedNucleusOfTheStriaTerminalis.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_bedNucleusOfTheStriaTerminalis.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_brachiumOfTheSuperiorColliculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_brachiumOfTheSuperiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_brainstemUnspecified.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_brainstemUnspecified.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_centralCanal.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_centralCanal.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_cingulateCortexArea2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_cingulateCortexArea2.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_cochlea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_cochlea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_cochlearNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_cochlearNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_commissuralStriaTerminalis.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_commissuralStriaTerminalis.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_commissureOfTheSuperiorColliculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_commissureOfTheSuperiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_cornuAmmonis1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_cornuAmmonis1.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_cornuAmmonis2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_cornuAmmonis2.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_cornuAmmonis3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_cornuAmmonis3.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_corpusCallosumAndAssociatedSubcorticalWhiteMatter.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_corpusCallosumAndAssociatedSubcorticalWhiteMatter.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_deeperCerebellum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_deeperCerebellum.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_deeperLayersOfTheSuperiorColliculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_deeperLayersOfTheSuperiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_dentateGyrus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_dentateGyrus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_descendingCorticofugalPathways.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_descendingCorticofugalPathways.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_dorsalCochlearNucleusDeepCore.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_dorsalCochlearNucleusDeepCore.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_dorsalCochlearNucleusFusiformAndGranuleLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_dorsalCochlearNucleusFusiformAndGranuleLayer.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_dorsalCochlearNucleusMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_dorsalCochlearNucleusMolecularLayer.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_entopeduncularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_entopeduncularNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_facialNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_facialNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_fasciculusRetroflexus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_fasciculusRetroflexus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_fasciolaCinereum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_fasciolaCinereum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_fimbriaOfTheHippocampus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_fimbriaOfTheHippocampus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_fornix.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_fornix.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_frontalAssociationCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_frontalAssociationCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_genuOfTheFacialNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_genuOfTheFacialNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_globusPallidus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_globusPallidus.jsonld
@@ -15,7 +15,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_glomerularLayerOfTheAccessoryOlfactoryBulb.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_glomerularLayerOfTheAccessoryOlfactoryBulb.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_glomerularLayerOfTheOlfactoryBulb.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_glomerularLayerOfTheOlfactoryBulb.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_habenularCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_habenularCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_hypothalamicRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_hypothalamicRegion.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_inferiorCerebellarPeduncle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_inferiorCerebellarPeduncle.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_inferiorColliculusBrachium.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_inferiorColliculusBrachium.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_inferiorColliculusCentralNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_inferiorColliculusCentralNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_inferiorColliculusCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_inferiorColliculusCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_inferiorColliculusDorsalCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_inferiorColliculusDorsalCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_inferiorColliculusExternalCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_inferiorColliculusExternalCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_inferiorOlive.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_inferiorOlive.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_interpeduncularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_interpeduncularNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_lateralEntorhinalCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_lateralEntorhinalCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_lateralLemniscus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_lateralLemniscus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_lateralLemniscusCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_lateralLemniscusCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_lateralLemniscusDorsalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_lateralLemniscusDorsalNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_lateralLemniscusIntermediateNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_lateralLemniscusIntermediateNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_lateralLemniscusVentralNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_lateralLemniscusVentralNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_lateralSuperiorOlive.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_lateralSuperiorOlive.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_mammillotegmentalTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_mammillotegmentalTract.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_medialEntorhinalCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_medialEntorhinalCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_medialGeniculateBodyDorsalDivision.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_medialGeniculateBodyDorsalDivision.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_medialGeniculateBodyMarginalZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_medialGeniculateBodyMarginalZone.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_medialGeniculateBodyMedialDivision.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_medialGeniculateBodyMedialDivision.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_medialGeniculateBodyVentralDivision.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_medialGeniculateBodyVentralDivision.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_medialLemniscus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_medialLemniscus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_medialLemniscusDecussation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_medialLemniscusDecussation.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_medialSuperiorOlive.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_medialSuperiorOlive.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_middleCerebellarPeduncle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_middleCerebellarPeduncle.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_molecularCellLayerOfTheCerebellum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_molecularCellLayerOfTheCerebellum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_neocortexUnspecified.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_neocortexUnspecified.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_nucleusOfTheStriaMedullaris.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_nucleusOfTheStriaMedullaris.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_nucleusOfTheTrapezoidBody.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_nucleusOfTheTrapezoidBody.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_nucleusSagulum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_nucleusSagulum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_olfactoryBulb.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_olfactoryBulb.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_opticNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_opticNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_opticTractAndOpticChiasm.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_opticTractAndOpticChiasm.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_parasubiculum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_parasubiculum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_periaqueductalGray.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_periaqueductalGray.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_perirhinalArea35.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_perirhinalArea35.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_perirhinalArea36.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_perirhinalArea36.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_periventricularGray.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_periventricularGray.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_pinealGland.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_pinealGland.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_pontineNuclei.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_pontineNuclei.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_posteriorCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_posteriorCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_postrhinalCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_postrhinalCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_presubiculum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_presubiculum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_pretectalRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_pretectalRegion.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_primaryAuditoryCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_primaryAuditoryCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_pyramidalDecussation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_pyramidalDecussation.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_reticularThalamicNucleusAuditorySegment.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_reticularThalamicNucleusAuditorySegment.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_secondaryAuditoryCortexDorsalArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_secondaryAuditoryCortexDorsalArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_secondaryAuditoryCortexVentralArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_secondaryAuditoryCortexVentralArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_septalRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_septalRegion.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_spinalCord.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_spinalCord.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_spinalTrigeminalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_spinalTrigeminalNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_spinalTrigeminalTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_spinalTrigeminalTract.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_spiralGanglion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_spiralGanglion.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_striaMedullarisOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_striaMedullarisOfTheThalamus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_striaTerminalis.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_striaTerminalis.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_striatum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_striatum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_subiculum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_subiculum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_substantiaNigra.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_substantiaNigra.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_subthalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_subthalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_superficialGrayLayerOfTheSuperiorColliculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_superficialGrayLayerOfTheSuperiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_superiorParaolivaryNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_superiorParaolivaryNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_superiorPeriolivaryRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_superiorPeriolivaryRegion.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_supraopticDecussation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_supraopticDecussation.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_thalamusUnspecified.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_thalamusUnspecified.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_transverseFibersOfThePons.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_transverseFibersOfThePons.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_trapezoidBody.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_trapezoidBody.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_ventralCochlearNucleusAnteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_ventralCochlearNucleusAnteriorPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_ventralCochlearNucleusCapArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_ventralCochlearNucleusCapArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_ventralCochlearNucleusGranuleCellLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_ventralCochlearNucleusGranuleCellLayer.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_ventralCochlearNucleusPosteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_ventralCochlearNucleusPosteriorPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_ventralHippocampalCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_ventralHippocampalCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_ventralPeriolivaryNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_ventralPeriolivaryNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_ventricularSystemUnspecified.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_ventricularSystemUnspecified.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_vestibularApparatus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_vestibularApparatus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_vestibularNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3.01/WHSSDatlas_v3.01_vestibularNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_4thVentricle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_4thVentricle.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_acousticStriae.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_acousticStriae.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_alveusOfTheHippocampus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_alveusOfTheHippocampus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_anteriorCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_anteriorCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_anteriorCommissureAnteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_anteriorCommissureAnteriorPart.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_anteriorCommissurePosteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_anteriorCommissurePosteriorPart.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_ascendingFibersOfTheFacialNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_ascendingFibersOfTheFacialNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_auditoryRadiation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_auditoryRadiation.jsonld
@@ -15,7 +15,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_basalForebrainRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_basalForebrainRegion.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_bedNucleusOfTheStriaTerminalis.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_bedNucleusOfTheStriaTerminalis.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_brachiumOfTheSuperiorColliculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_brachiumOfTheSuperiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_brainstem.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_brainstem.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_centralCanal.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_centralCanal.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_cingulateCortexArea2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_cingulateCortexArea2.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_cochlea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_cochlea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_cochlearNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_cochlearNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_commissuralStriaTerminalis.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_commissuralStriaTerminalis.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_commissureOfTheSuperiorColliculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_commissureOfTheSuperiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_cornuAmmonis1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_cornuAmmonis1.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_cornuAmmonis2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_cornuAmmonis2.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_cornuAmmonis3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_cornuAmmonis3.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_corpusCallosumAndAssociatedSubcorticalWhiteMatter.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_corpusCallosumAndAssociatedSubcorticalWhiteMatter.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_deeperLayersOfTheSuperiorColliculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_deeperLayersOfTheSuperiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_dentateGyrus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_dentateGyrus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_descendingCorticofugalPathways.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_descendingCorticofugalPathways.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_dorsalCochlearNucleusDeepCore.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_dorsalCochlearNucleusDeepCore.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_dorsalCochlearNucleusFusiformAndGranuleLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_dorsalCochlearNucleusFusiformAndGranuleLayer.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_dorsalCochlearNucleusMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_dorsalCochlearNucleusMolecularLayer.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_entopeduncularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_entopeduncularNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_entorhinalCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_entorhinalCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_facialNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_facialNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_fasciculusRetroflexus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_fasciculusRetroflexus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_fasciolaCinereum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_fasciolaCinereum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_fimbriaOfTheHippocampus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_fimbriaOfTheHippocampus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_fornix.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_fornix.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_frontalAssociationCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_frontalAssociationCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_genuOfTheFacialNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_genuOfTheFacialNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_globusPallidus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_globusPallidus.jsonld
@@ -15,7 +15,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_glomerularLayerOfTheAccessoryOlfactoryBulb.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_glomerularLayerOfTheAccessoryOlfactoryBulb.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_glomerularLayerOfTheOlfactoryBulb.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_glomerularLayerOfTheOlfactoryBulb.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_granuleCellLevelOfTheCerebellum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_granuleCellLevelOfTheCerebellum.jsonld
@@ -15,7 +15,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_habenularCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_habenularCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_hypothalamicRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_hypothalamicRegion.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_inferiorCerebellarPeduncle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_inferiorCerebellarPeduncle.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_inferiorColliculusBrachium.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_inferiorColliculusBrachium.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_inferiorColliculusCentralNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_inferiorColliculusCentralNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_inferiorColliculusCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_inferiorColliculusCommissure.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_inferiorColliculusDorsalCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_inferiorColliculusDorsalCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_inferiorColliculusExternalCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_inferiorColliculusExternalCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_inferiorOlive.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_inferiorOlive.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_interpeduncularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_interpeduncularNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_lateralEntorhinalCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_lateralEntorhinalCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_lateralLemniscus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_lateralLemniscus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_lateralLemniscusCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_lateralLemniscusCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_lateralLemniscusDorsalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_lateralLemniscusDorsalNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_lateralLemniscusIntermediateNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_lateralLemniscusIntermediateNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_lateralLemniscusVentralNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_lateralLemniscusVentralNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_lateralSuperiorOlive.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_lateralSuperiorOlive.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_mammillothalamicTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_mammillothalamicTract.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_medialGeniculateBodyDorsalDivision.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_medialGeniculateBodyDorsalDivision.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_medialGeniculateBodyMarginalZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_medialGeniculateBodyMarginalZone.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_medialGeniculateBodyMedialDivision.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_medialGeniculateBodyMedialDivision.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_medialGeniculateBodyVentralDivision.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_medialGeniculateBodyVentralDivision.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_medialLemniscus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_medialLemniscus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_medialLemniscusDecussation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_medialLemniscusDecussation.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_medialSuperiorOlive.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_medialSuperiorOlive.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_middleCerebellarPeduncle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_middleCerebellarPeduncle.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_molecularLayerOfTheCerebellum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_molecularLayerOfTheCerebellum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_neocortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_neocortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_nucleusOfTheStriaMedullaris.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_nucleusOfTheStriaMedullaris.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_nucleusOfTheTrapezoidBody.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_nucleusOfTheTrapezoidBody.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_nucleusSagulum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_nucleusSagulum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_olfactoryBulb.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_olfactoryBulb.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_opticNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_opticNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_opticTractAndOpticChiasm.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_opticTractAndOpticChiasm.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_parasubiculum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_parasubiculum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_periaqueductalGray.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_periaqueductalGray.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_perirhinalArea35.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_perirhinalArea35.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_perirhinalArea36.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_perirhinalArea36.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_periventricularGray.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_periventricularGray.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_pinealGland.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_pinealGland.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_pontineNuclei.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_pontineNuclei.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_posteriorCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_posteriorCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_postrhinalCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_postrhinalCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_presubiculum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_presubiculum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_pretectalRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_pretectalRegion.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_primaryAuditoryCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_primaryAuditoryCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_pyramidalDecussation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_pyramidalDecussation.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_reticularThalamicNucleusAuditorySegment.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_reticularThalamicNucleusAuditorySegment.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_secondaryAuditoryCortexDorsalArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_secondaryAuditoryCortexDorsalArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_secondaryAuditoryCortexVentralArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_secondaryAuditoryCortexVentralArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_septalRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_septalRegion.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_spinalCord.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_spinalCord.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_spinalTrigeminalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_spinalTrigeminalNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_spinalTrigeminalTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_spinalTrigeminalTract.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_spiralGanglion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_spiralGanglion.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_striaMedullarisOfTheThalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_striaMedullarisOfTheThalamus.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_striaTerminalis.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_striaTerminalis.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_striatum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_striatum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_subiculum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_subiculum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_substantiaNigra.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_substantiaNigra.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_subthalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_subthalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_superficialGrayLayerOfTheSuperiorColliculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_superficialGrayLayerOfTheSuperiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_superiorParaolivaryNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_superiorParaolivaryNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_superiorPeriolivaryRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_superiorPeriolivaryRegion.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_supraopticDecussation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_supraopticDecussation.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_thalamus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_thalamus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_transverseFibersOfThePons.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_transverseFibersOfThePons.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_trapezoidBody.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_trapezoidBody.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_ventralCochlearNucleusAnteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_ventralCochlearNucleusAnteriorPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_ventralCochlearNucleusCapArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_ventralCochlearNucleusCapArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_ventralCochlearNucleusGranuleCellLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_ventralCochlearNucleusGranuleCellLayer.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_ventralCochlearNucleusPosteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_ventralCochlearNucleusPosteriorPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_ventralHippocampalCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_ventralHippocampalCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_ventralPeriolivaryNuclei.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_ventralPeriolivaryNuclei.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_ventricularSystem.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_ventricularSystem.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_vestibularApparatus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_vestibularApparatus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_vestibularNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v3/WHSSDatlas_v3_vestibularNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_4thVentricle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_4thVentricle.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_acousticStriae.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_acousticStriae.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_agranularInsularCortexDorsalArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_agranularInsularCortexDorsalArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_agranularInsularCortexPosteriorArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_agranularInsularCortexPosteriorArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_agranularInsularCortexVentralArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_agranularInsularCortexVentralArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_alveusOfTheHippocampus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_alveusOfTheHippocampus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_amygdaloidAreaUnspecified.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_amygdaloidAreaUnspecified.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_angularThalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_angularThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_anteriorCommissureAnteriorLimb.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_anteriorCommissureAnteriorLimb.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_anteriorCommissureIntrabulbarPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_anteriorCommissureIntrabulbarPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_anteriorCommissurePosteriorLimb.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_anteriorCommissurePosteriorLimb.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_anterodorsalThalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_anterodorsalThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_anteromedialThalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_anteromedialThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_anteroventralThalamicNucleusDorsomedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_anteroventralThalamicNucleusDorsomedialPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_anteroventralThalamicNucleusVentrolateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_anteroventralThalamicNucleusVentrolateralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ascendingFibersOfTheFacialNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ascendingFibersOfTheFacialNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_basalForebrainRegionUnspecified.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_basalForebrainRegionUnspecified.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_bedNucleusOfTheStriaTerminalis.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_bedNucleusOfTheStriaTerminalis.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_brachiumOfTheSuperiorColliculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_brachiumOfTheSuperiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_brainstemUnspecified.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_brainstemUnspecified.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_caudatePutamen.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_caudatePutamen.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_centralCanal.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_centralCanal.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_centralLateralThalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_centralLateralThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_centralMedialThalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_centralMedialThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_cerebellumUnspecified.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_cerebellumUnspecified.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_cingulateArea1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_cingulateArea1.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_cingulateArea2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_cingulateArea2.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_claustrum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_claustrum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_cochlea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_cochlea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_cochlearNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_cochlearNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_commissuralStriaTerminalis.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_commissuralStriaTerminalis.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_commissureOfTheSuperiorColliculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_commissureOfTheSuperiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_cornuAmmonis1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_cornuAmmonis1.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_cornuAmmonis2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_cornuAmmonis2.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_cornuAmmonis3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_cornuAmmonis3.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_corpusCallosumAndAssociatedSubcorticalWhiteMatter.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_corpusCallosumAndAssociatedSubcorticalWhiteMatter.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_corticofugalTractAndCoronaRadiata.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_corticofugalTractAndCoronaRadiata.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_deeperLayersOfTheSuperiorColliculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_deeperLayersOfTheSuperiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_dentateGyrus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_dentateGyrus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_dorsalCochlearNucleusDeepCore.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_dorsalCochlearNucleusDeepCore.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_dorsalCochlearNucleusFusiformAndGranuleLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_dorsalCochlearNucleusFusiformAndGranuleLayer.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_dorsalCochlearNucleusMolecularLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_dorsalCochlearNucleusMolecularLayer.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_dorsalLateralGeniculateNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_dorsalLateralGeniculateNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_dorsolateralOrbitalArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_dorsolateralOrbitalArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_dysgranularInsularCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_dysgranularInsularCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_endopiriformNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_endopiriformNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_entopeduncularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_entopeduncularNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ethmoidLimitansNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ethmoidLimitansNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_externalMedullaryLaminaAuditoryRadiation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_externalMedullaryLaminaAuditoryRadiation.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_externalMedullaryLaminaUnspecified.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_externalMedullaryLaminaUnspecified.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_facialNerveUnspecified.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_facialNerveUnspecified.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_fasciculusRetroflexus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_fasciculusRetroflexus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_fasciolaCinereum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_fasciolaCinereum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_fieldsOfForel.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_fieldsOfForel.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_fimbriaOfTheHippocampus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_fimbriaOfTheHippocampus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_fornix.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_fornix.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_frontalAssociationArea3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_frontalAssociationArea3.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_frontalAssociationCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_frontalAssociationCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_genuOfTheFacialNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_genuOfTheFacialNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_globusPallidusExternalLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_globusPallidusExternalLateralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_globusPallidusExternalMedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_globusPallidusExternalMedialPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_glomerularLayerOfTheAccessoryOlfactoryBulb.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_glomerularLayerOfTheAccessoryOlfactoryBulb.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_glomerularLayerOfTheOlfactoryBulb.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_glomerularLayerOfTheOlfactoryBulb.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_granularInsularCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_granularInsularCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_habenularCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_habenularCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_hypothalamicRegionUnspecified.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_hypothalamicRegionUnspecified.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_inferiorCerebellarPeduncle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_inferiorCerebellarPeduncle.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_inferiorColliculusBrachium.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_inferiorColliculusBrachium.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_inferiorColliculusCentralNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_inferiorColliculusCentralNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_inferiorColliculusCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_inferiorColliculusCommissure.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_inferiorColliculusDorsalCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_inferiorColliculusDorsalCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_inferiorColliculusExternalCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_inferiorColliculusExternalCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_inferiorOlive.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_inferiorOlive.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_infralimbicArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_infralimbicArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_interanteromedialThalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_interanteromedialThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_intergeniculateLeaflet.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_intergeniculateLeaflet.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_intermediodorsalThalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_intermediodorsalThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_internalMedullaryLamina.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_internalMedullaryLamina.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_interpeduncularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_interpeduncularNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_intramedullaryThalamicArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_intramedullaryThalamicArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralEntorhinalCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralEntorhinalCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralHabenularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralHabenularNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralLemniscusCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralLemniscusCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralLemniscusDorsalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralLemniscusDorsalNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralLemniscusIntermediateNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralLemniscusIntermediateNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralLemniscusUnspecified.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralLemniscusUnspecified.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralLemniscusVentralNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralLemniscusVentralNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralOlfactoryTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralOlfactoryTract.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralOrbitalArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralOrbitalArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralPosteriorThalamicNucleusLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralPosteriorThalamicNucleusLateralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralPosteriorThalamicNucleusMediocaudalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralPosteriorThalamicNucleusMediocaudalPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralPosteriorThalamicNucleusMediorostralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralPosteriorThalamicNucleusMediorostralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralSuperiorOlive.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_lateralSuperiorOlive.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_laterodorsalThalamicNucleusDorsomedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_laterodorsalThalamicNucleusDorsomedialPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_laterodorsalThalamicNucleusVentrolateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_laterodorsalThalamicNucleusVentrolateralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_mammillotegmentalTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_mammillotegmentalTract.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialEntorhinalCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialEntorhinalCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialGeniculateBodyDorsalDivision.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialGeniculateBodyDorsalDivision.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialGeniculateBodyMarginalZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialGeniculateBodyMarginalZone.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialGeniculateBodyMedialDivision.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialGeniculateBodyMedialDivision.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialGeniculateBodySuprageniculateNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialGeniculateBodySuprageniculateNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialGeniculateBodyVentralDivision.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialGeniculateBodyVentralDivision.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialHabenularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialHabenularNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialLemniscusDecussation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialLemniscusDecussation.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialLemniscusUnspecified.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialLemniscusUnspecified.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialOrbitalArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialOrbitalArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialSuperiorOlive.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_medialSuperiorOlive.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_mediodorsalThalamicNucleusCentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_mediodorsalThalamicNucleusCentralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_mediodorsalThalamicNucleusLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_mediodorsalThalamicNucleusLateralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_mediodorsalThalamicNucleusMedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_mediodorsalThalamicNucleusMedialPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_middleCerebellarPeduncle.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_middleCerebellarPeduncle.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_molecularCellLayerOfTheCerebellum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_molecularCellLayerOfTheCerebellum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_nucleusAccumbensCore.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_nucleusAccumbensCore.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_nucleusAccumbensShell.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_nucleusAccumbensShell.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_nucleusOfTheLateralOlfactoryTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_nucleusOfTheLateralOlfactoryTract.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_nucleusOfTheStriaMedullaris.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_nucleusOfTheStriaMedullaris.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_nucleusOfTheTrapezoidBody.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_nucleusOfTheTrapezoidBody.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_nucleusSagulum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_nucleusSagulum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_olfactoryBulbUnspecified.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_olfactoryBulbUnspecified.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_opticNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_opticNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_opticTractAndOpticChiasm.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_opticTractAndOpticChiasm.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_paracentralThalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_paracentralThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_parafascicularThalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_parafascicularThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_parasubiculum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_parasubiculum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_parataenialThalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_parataenialThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_paraventricularThalamicNucleiAnteriorAndPosterior.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_paraventricularThalamicNucleiAnteriorAndPosterior.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_parietalAssociationCortexLateralArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_parietalAssociationCortexLateralArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_parietalAssociationCortexMedialArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_parietalAssociationCortexMedialArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_parietalAssociationCortexPosteriorArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_parietalAssociationCortexPosteriorArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_periaqueductalGray.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_periaqueductalGray.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_peripeduncularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_peripeduncularNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_perirhinalArea35.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_perirhinalArea35.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_perirhinalArea36.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_perirhinalArea36.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_periventricularGray.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_periventricularGray.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_pinealGland.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_pinealGland.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_piriformCortexLayer1.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_piriformCortexLayer1.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_piriformCortexLayer2.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_piriformCortexLayer2.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_piriformCortexLayer3.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_piriformCortexLayer3.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_pontineNuclei.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_pontineNuclei.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_posteriorCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_posteriorCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_posteriorIntralaminarNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_posteriorIntralaminarNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_posteriorThalamicNuclearGroupTriangularPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_posteriorThalamicNuclearGroupTriangularPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_posteriorThalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_posteriorThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_postrhinalCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_postrhinalCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_pregeniculateNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_pregeniculateNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_prelimbicArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_prelimbicArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_presubiculum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_presubiculum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_pretectalRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_pretectalRegion.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_pretectothalamicLamina.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_pretectothalamicLamina.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_primaryAuditoryArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_primaryAuditoryArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_primaryMotorArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_primaryMotorArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_primarySomatosensoryAreaBarrelField.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_primarySomatosensoryAreaBarrelField.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_primarySomatosensoryAreaDysgranularZone.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_primarySomatosensoryAreaDysgranularZone.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_primarySomatosensoryAreaFaceRepresentation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_primarySomatosensoryAreaFaceRepresentation.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_primarySomatosensoryAreaForelimbRepresentation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_primarySomatosensoryAreaForelimbRepresentation.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_primarySomatosensoryAreaHindlimbRepresentation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_primarySomatosensoryAreaHindlimbRepresentation.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_primarySomatosensoryAreaTrunkRepresentation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_primarySomatosensoryAreaTrunkRepresentation.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_primaryVisualArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_primaryVisualArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_pyramidalDecussation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_pyramidalDecussation.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_reticularPrethalamicNucleusAuditorySegment.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_reticularPrethalamicNucleusAuditorySegment.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_reticularPrethalamicNucleusUnspecified.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_reticularPrethalamicNucleusUnspecified.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_retroreuniensThalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_retroreuniensThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_retrosplenialDysgranularArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_retrosplenialDysgranularArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_retrosplenialGranularArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_retrosplenialGranularArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_reuniensThalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_reuniensThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_rhomboidThalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_rhomboidThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_secondaryAuditoryAreaDorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_secondaryAuditoryAreaDorsalPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_secondaryAuditoryAreaVentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_secondaryAuditoryAreaVentralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_secondaryMotorArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_secondaryMotorArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_secondarySomatosensoryArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_secondarySomatosensoryArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_secondaryVisualAreaLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_secondaryVisualAreaLateralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_secondaryVisualAreaMedialPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_secondaryVisualAreaMedialPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_septalRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_septalRegion.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_spinalCord.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_spinalCord.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_spinalTrigeminalNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_spinalTrigeminalNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_spinalTrigeminalTract.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_spinalTrigeminalTract.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_spiralGanglion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_spiralGanglion.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_striaMedullarisThalami.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_striaMedullarisThalami.jsonld
@@ -14,7 +14,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_striaTerminalis.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_striaTerminalis.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_subgeniculateNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_subgeniculateNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_subiculum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_subiculum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_submediusThalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_submediusThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_subparafascicularNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_subparafascicularNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_substantiaNigraCompactPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_substantiaNigraCompactPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_substantiaNigraLateralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_substantiaNigraLateralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_substantiaNigraReticularPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_substantiaNigraReticularPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_subthalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_subthalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_superficialGrayLayerOfTheSuperiorColliculus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_superficialGrayLayerOfTheSuperiorColliculus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_superiorCerebellarPeduncleAndPrerubralField.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_superiorCerebellarPeduncleAndPrerubralField.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_superiorParaolivaryNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_superiorParaolivaryNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_superiorPeriolivaryRegion.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_superiorPeriolivaryRegion.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_supraopticDecussation.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_supraopticDecussation.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_temporalAssociationCortex.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_temporalAssociationCortex.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_transverseFibersOfThePons.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_transverseFibersOfThePons.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_trapezoidBody.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_trapezoidBody.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralAnteriorThalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralAnteriorThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralCochlearNucleusAnteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralCochlearNucleusAnteriorPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralCochlearNucleusCapArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralCochlearNucleusCapArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralCochlearNucleusGranuleCellLayer.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralCochlearNucleusGranuleCellLayer.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralCochlearNucleusPosteriorPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralCochlearNucleusPosteriorPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralHippocampalCommissure.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralHippocampalCommissure.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralOrbitalArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralOrbitalArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralPallidum.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralPallidum.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralPeriolivaryNuclei.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralPeriolivaryNuclei.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralPosteriorNucleusOfTheThalamusParvicellularPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralPosteriorNucleusOfTheThalamusParvicellularPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralPosterolateralThalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralPosterolateralThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralPosteromedialThalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralPosteromedialThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralStriatalRegionUnspecified.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralStriatalRegionUnspecified.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralTegmentalArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventralTegmentalArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventricularSystemUnspecified.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventricularSystemUnspecified.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventrolateralOrbitalArea.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventrolateralOrbitalArea.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventrolateralThalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventrolateralThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventromedialThalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_ventromedialThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_vestibularApparatus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_vestibularApparatus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_vestibularNerve.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_vestibularNerve.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_xiphoidThalamicNucleus.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_xiphoidThalamicNucleus.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_zonaIncertaA11DopamineCells.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_zonaIncertaA11DopamineCells.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_zonaIncertaA13DopamineCells.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_zonaIncertaA13DopamineCells.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_zonaIncertaCaudalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_zonaIncertaCaudalPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_zonaIncertaDorsalPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_zonaIncertaDorsalPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_zonaIncertaRostralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_zonaIncertaRostralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"

--- a/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_zonaIncertaVentralPart.jsonld
+++ b/instances/v5.0/parcellationEntityVersions/WHSSDatlas_v4/WHSSDatlas_v4_zonaIncertaVentralPart.jsonld
@@ -13,7 +13,6 @@
   "hasAnnotation": [
     {
       "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
-      "anchorPoint": null,
       "criteria": null,
       "criteriaQualityType": {
         "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"


### PR DESCRIPTION
Cleanup for latest and v5.0
anchorPoint is only deleted in hasAnnotation, we keep it in preferredVisualization (ViewerSpecification): e.g., AMBA_CCFv3-2017_laterointermediateAreaLayer1.jsonld