### PR TITLE
Upstream pipeline - conditional trigger on success for the autopopulation pipeline

### DIFF
--- a/.github/workflows/openMINDS_upstream.yml
+++ b/.github/workflows/openMINDS_upstream.yml
@@ -12,6 +12,7 @@ on:
   
 jobs:
   build:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
     - name: Trigger target repositories


### PR DESCRIPTION
This will enforce to trigger the upstream pipeline only on success of the autopopulation pipeline.