### PR TITLE
Fix text_x-fastq.jsonld

### DIFF
--- a/instances/latest/contentTypes/text_x-fastq.jsonld
+++ b/instances/latest/contentTypes/text_x-fastq.jsonld
@@ -4,18 +4,20 @@
   },
   "@id": "https://openminds.om-i.org/instances/contentTypes/text_x-fastq",
   "@type": "https://openminds.om-i.org/types/ContentType",
-  "dataType": null,
+  "dataType": [
+    {
+      "id": "https://openminds.om-i.org/instances/dataType/table"
+    }
+  ],
   "definingSource": null,
   "description": "A text-based format for storing both a biological sequence (usually nucleotide sequence) and its corresponding quality scores.",
-  "displayLabel": null,
+  "displayLabel": "FASTQ Format",
   "fileExtension": [
-    ".fg",
-    ".fg.gz"
+    ".fastq",
+    ".fq"
   ],
   "isBasedOn": null,
   "name": "text/x-fastq",
-  "specification": "https://en.wikipedia.org/wiki/FASTQ_format",
-  "synonym": [
-    "FASTQ Format"
-  ]
+  "specification": "https://maq.sourceforge.net/fastq.shtml",
+  "synonym": null
 }

--- a/instances/latest/contentTypes/text_x-fastq.jsonld
+++ b/instances/latest/contentTypes/text_x-fastq.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.om-i.org/types/ContentType",
   "dataType": [
     {
-      "id": "https://openminds.om-i.org/instances/dataType/table"
+      "@id": "https://openminds.om-i.org/instances/dataType/table"
     }
   ],
   "definingSource": null,


### PR DESCRIPTION
- Add official format specification page
- Fix fileExtensions (we may want to add the .gz versions)
- The dataType format seems to be close to a table

From my understanding it is based on FASTA which is not yet in openMINDS